### PR TITLE
incorrect encoding of a minus sign

### DIFF
--- a/hyperv-tools/DiscreteDeviceAssignment/SurveyDDA.ps1
+++ b/hyperv-tools/DiscreteDeviceAssignment/SurveyDDA.ps1
@@ -119,7 +119,7 @@ foreach ($pcidev in $pcidevs) {
     {
         $baseAdd =$mem.Antecedent.SubString($mem.Antecedent.IndexOf("""")+1)
         $baseAdd=$baseAdd.SubString(0,$baseAdd.IndexOf(""""))
-        $mmioRange = gwmi -query "select * from Win32_DeviceMemoryAddress" | Where-Object{$_.StartingAddress –like $baseAdd}
+        $mmioRange = gwmi -query "select * from Win32_DeviceMemoryAddress" | Where-Object{$_.StartingAddress -like $baseAdd}
         $mmioTotal = $mmioTotal + $mmioRange.EndingAddress - $mmioRange.StartingAddress
     }
     if ($mmioTotal -eq 0)


### PR DESCRIPTION
minus sign as a command line option must be ASCII, not a mathematical minus symbol