### PR TITLE
Add path checking, output OS Build Label

### DIFF
--- a/windows-server-container-tools/Debug-ContainerHost/Debug-ContainerHost.ps1
+++ b/windows-server-container-tools/Debug-ContainerHost/Debug-ContainerHost.ps1
@@ -287,5 +287,11 @@ $events | Export-CSV $eventCsv
 Write-Host "Logs saved to $($PWD)\$($eventCsv)`n`n"
 
 Write-Output "Getting Docker for Windows daemon logs from the last execution"
-Write-Output "    Note: More logs are available at $($ENV:LOCALAPPDATA)\Docker. Only showing the latest."
-Get-Content "$($ENV:LOCALAPPDATA)\Docker\log.txt" | Select-String "WindowsDockerDaemon"
+Write-Output "    Note: More logs may be available at $($ENV:LOCALAPPDATA)\Docker. Only showing the latest."
+if (Test-Path "$($ENV:LOCALAPPDATA)\Docker\log.txt")
+{
+	Get-Content "$($ENV:LOCALAPPDATA)\Docker\log.txt" | Select-String "WindowsDockerDaemon"
+}
+else {
+	Write-Output "   $($ENV:LOCALAPPDATA)\Docker\log.txt does not exist."
+}

--- a/windows-server-container-tools/Debug-ContainerHost/Debug-ContainerHost.ps1
+++ b/windows-server-container-tools/Debug-ContainerHost/Debug-ContainerHost.ps1
@@ -2,8 +2,10 @@ Write-Output "Checking for common problems"
 
 $filesToDump = @{}
 $currentVersion = Get-Item 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion'
+$OSProductName = $currentVersion.GetValue('ProductName')
 $OSBuildLabel = $currentVersion.GetValue('BuildLabEx')
-Write-Output "Windows Build Label: $OSBuildLabel"
+Write-Output "Container Host OS Product Name: $OSProductName"
+Write-Output "Container Host Build Label: $OSBuildLabel"
 
 Describe "Windows Version and Prerequisites" {
     $buildNumber = (Get-CimInstance -Namespace root\cimv2 Win32_OperatingSystem).BuildNumber

--- a/windows-server-container-tools/Debug-ContainerHost/Debug-ContainerHost.ps1
+++ b/windows-server-container-tools/Debug-ContainerHost/Debug-ContainerHost.ps1
@@ -5,7 +5,7 @@ $currentVersion = Get-Item 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion'
 $OSProductName = $currentVersion.GetValue('ProductName')
 $OSBuildLabel = $currentVersion.GetValue('BuildLabEx')
 Write-Output "Container Host OS Product Name: $OSProductName"
-Write-Output "Container Host Build Label: $OSBuildLabel"
+Write-Output "Container Host OS Build Label: $OSBuildLabel"
 
 Describe "Windows Version and Prerequisites" {
     $buildNumber = (Get-CimInstance -Namespace root\cimv2 Win32_OperatingSystem).BuildNumber

--- a/windows-server-container-tools/Debug-ContainerHost/Debug-ContainerHost.ps1
+++ b/windows-server-container-tools/Debug-ContainerHost/Debug-ContainerHost.ps1
@@ -290,10 +290,10 @@ $events | Export-CSV $eventCsv
 Write-Host "Logs saved to $($PWD)\$($eventCsv)`n`n"
 
 Write-Output "Getting Docker for Windows daemon logs from the last execution"
-Write-Output "    Note: More logs may be available at $($ENV:LOCALAPPDATA)\Docker. Only showing the latest."
+Write-Output "    Note: More logs may be available at $($ENV:LOCALAPPDATA)\Docker. Only showing the latest 100 lines."
 if (Test-Path "$($ENV:LOCALAPPDATA)\Docker\log.txt")
 {
-	Get-Content "$($ENV:LOCALAPPDATA)\Docker\log.txt" | Select-String "WindowsDockerDaemon"
+	Get-Content -Tail 100 "$($ENV:LOCALAPPDATA)\Docker\log.txt" | Select-String "WindowsDockerDaemon"
 }
 else {
 	Write-Output "   $($ENV:LOCALAPPDATA)\Docker\log.txt does not exist."

--- a/windows-server-container-tools/Debug-ContainerHost/Debug-ContainerHost.ps1
+++ b/windows-server-container-tools/Debug-ContainerHost/Debug-ContainerHost.ps1
@@ -1,6 +1,9 @@
 Write-Output "Checking for common problems"
 
 $filesToDump = @{}
+$currentVersion = Get-Item 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion'
+$OSBuildLabel = $currentVersion.GetValue('BuildLabEx')
+Write-Output "Windows Build Label: $OSBuildLabel"
 
 Describe "Windows Version and Prerequisites" {
     $buildNumber = (Get-CimInstance -Namespace root\cimv2 Win32_OperatingSystem).BuildNumber


### PR DESCRIPTION
Fix bug encountered when running script on Windows Server 2016 hosts where the log that is output to the  screen does not exist.  Added a path check to determine if the log exists before retrieving the content and outputting it to the screen.  If the log doesn't exist, the output declares that to the user.

Added logic to only display the last 100 lines of the log to the user in the terminal.  I found that outputting more than that risks pushing the test results out of the output that can be scrolled through in a powershell terminal.  The path is printed in the output and the user can refer to the file if they need more data.

Added output logic to provide the Windows OS Product Name and Build Label.  Some of the github issues on the moby/moby project indicate that some adverse behaviors may be related to a particular OS build.  Windows Server 2016 Standard vs Windows Server 2016 Core.  Having this information may allow developers to correlate issues to a particular patch level and product