### PR TITLE
fix TOC not highlighting

### DIFF
--- a/virtualization/windowscontainers/TOC.md
+++ b/virtualization/windowscontainers/TOC.md
@@ -22,9 +22,9 @@
 
 # Manage Docker on Windows
 ## [Docker Engine on Windows](docker/configure_docker_daemon.md)
-## [Dockerfiles on Windows](docker/manage_windows_dockerfile.md)
-## [Optimize Dockerfiles](docker/optimize_windows_dockerfile.md)
-## [Container Networking](management/container_networking.md)
+## [Dockerfiles on Windows](manage-docker/manage-windows-dockerfile.md)
+## [Optimize Dockerfiles](manage-docker/optimize-windows-dockerfile.md)
+## [Container Networking](manage-containers/container-networking.md)
 ## [Getting Started with Swarm Mode](manage-containers/swarm-mode.md)
 ## [Manage Docker with PowerShell](https://github.com/Microsoft/Docker-PowerShell)
 ## [Remote Management of a Windows Docker Host](management/manage_remotehost.md)


### PR DESCRIPTION
I followed the tweet from MicrosoftDocs today and noticed the entry on the TOC was not highlighting.

So fixing the TOC to go to the right link so you can get the entry highlighted in the TOC.

Ideally, you'd have a master redirection file instead of doing the redirect on the files themselves so you'd get broken links in the build report when moving things around.