### PR TITLE
Display \ character

### DIFF
--- a/virtualization/windowscontainers/manage-docker/optimize-windows-dockerfile.md
+++ b/virtualization/windowscontainers/manage-docker/optimize-windows-dockerfile.md
@@ -79,7 +79,7 @@ a395ca26777f        15 seconds ago      cmd /S /C powershell.exe -Command Remove
 957147160e8d        3 minutes ago       cmd /S /C powershell.exe -Command Invoke-WebR   125.7 MB
 ```
 
-To compare, here is the same operation, however all steps run with the same `RUN` instruction. Note that each step in the `RUN` instruction is on a new line of the Dockerfile, the '\' character is being used to line wrap. 
+To compare, here is the same operation, however all steps run with the same `RUN` instruction. Note that each step in the `RUN` instruction is on a new line of the Dockerfile, the '\\' character is being used to line wrap. 
 
 ```
 FROM windowsservercore


### PR DESCRIPTION
Currently the \ within ```in the '\' character is being used to line wrap``` from [windowscontainers/manage-docker/optimize-windows-dockerfile](https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-docker/optimize-windows-dockerfile#optimize-image-size) is not being displayed which makes reading the line strange. 