### PR TITLE
Removed instructions for manual image creation

### DIFF
--- a/virtualization/windowscontainers/quick-start/quick-start-images.md
+++ b/virtualization/windowscontainers/quick-start/quick-start-images.md
@@ -12,7 +12,7 @@ ms.assetid: 479e05b1-2642-47c7-9db4-d2a23592d29f
 
 # Automating Builds and Saving Images
 
-In the previous Windows Server quick start, a Windows container was created from a pre-created .Net Core sample. This exercise will detail creating custom container images manually, automating container image creation using a Dockerfile, and storing container images in the Docker Hub public registry.
+In the previous Windows Server quick start, a Windows container was created from a pre-created .Net Core sample. This exercise will detail automating container image creation using a Dockerfile, and storing container images in the Docker Hub public registry.
 
 This quick start is specific to Windows Server containers on Windows Server 2016 and will use the Windows Server Core container base image. Additional quick start documentation can be found in the table of contents on the left hand side of this page.
 
@@ -22,82 +22,9 @@ This quick start is specific to Windows Server containers on Windows Server 2016
 - Configure this system with the Windows Container feature and Docker. For a walkthrough on these steps, see [Windows Containers on Windows Server](./quick-start-windows-server.md).
 - A Docker ID, this will be used to push a container image to Docker Hub. If you do not have a Docker ID, sign up for one at [Docker Cloud](https://cloud.docker.com/).
 
-## 1. Container Image - Manual
+## 1. Container Image - Dockerfile
 
-For the best experience, walk through this exercise from a Windows command shell (cmd.exe).
-
-The first step in manually creating a container image is to deploy a container. For this example, deploy an IIS container from the pre-created IIS image. Once the container has been deployed, you will be working in a shell session from within the container. The interactive session is initiated with the `-it` flag. For in depth details on Docker Run commands, see [Docker Run Reference on Docker.com](https://docs.docker.com/engine/reference/run/). 
-
-> This step may take some time due to the size of the Windows Server Core base image.
-
-```
-docker run -d --name myIIS -p 80:80 microsoft/iis
-```
-
-Now, the container will be running in the background. The default command included in the container, `ServiceMonitor.exe`, which monitor IIS progress and automatically stop the container if IIS stops. To learn more on how this image was created, see [Microsoft/docker-iis](https://github.com/Microsoft/iis-docker) on GitHub.
-
-Next, start an interactive cmd in the container. This will allow you to run commands in running container without stopping IIS or ServiceMonitor.
-
-```
-docker exec -i myIIS cmd 
-```
-
-Next, you can make a change to the running container. Run the following command to remove the IIS splash screen.
-
-```
-del C:\inetpub\wwwroot\iisstart.htm
-```
-
-And the following to replace the default IIS site with a new static site.
-
-```
-echo "Hello World From a Windows Server Container" > C:\inetpub\wwwroot\index.html
-```
-
-From a different system, browse to the IP address of the container host. You should now see the ‘Hello World’ application.
-
-**Note:** if you are working in Azure, a network security group rule will need to exist allowing traffic over port 80. For more information see, [Create Rule in a Network Security Group](https://azure.microsoft.com/en-us/documentation/articles/virtual-networks-create-nsg-arm-pportal/#create-rules-in-an-existing-nsg).
-
-![](media/hello.png)
-
-Back in the container, exit the interactive container session.
-
-```
-exit
-```
-
-The modified container can now be captured into a new container image. To do so, you will need the container name. This can be found using the `docker ps -a` command.
-
-```
-docker ps -a
-
-CONTAINER ID     IMAGE                             COMMAND   CREATED             STATUS   PORTS   NAMES
-489b0b447949     microsoft/iis   "cmd"     About an hour ago   Exited           pedantic_lichterman
-```
-
-To create a the new container image, use the `docker commit` command. Docker commit takes a form of “docker commit container-name new-image-name”. Note – replace the name of the container in this example with the actual container name.
-
-```
-docker commit pedantic_lichterman modified-iis
-```
-
-To verify that new image has been created, use the `docker images` command.  
-
-```
-docker images
-
-REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
-modified-iis        latest              3e4fdb6ed3bc        About a minute ago   10.17 GB
-microsoft/iis       windowsservercore   c26f4ceb81db        2 weeks ago          9.48 GB
-windowsservercore   10.0.14300.1000     dbfee88ee9fd        8 weeks ago          9.344 GB
-windowsservercore   latest              dbfee88ee9fd        8 weeks ago          9.344 GB
-```
-
-This image can now be deployed. The resulting container will include all captured modifications.
-
-## 2. Container Image - Dockerfile
-
-Through the last exercise, a container was manually created, modified, and then captured into a new container image. Docker includes a method for automating this process using a Dockerfile. This exercise will have almost identical results as the last, however this time the process will be automated. For this exercise, a Docker ID is required. If you do not have a Docker ID, sign up for one at [Docker Cloud]( https://cloud.docker.com/).
+Although a container can be manually created, modified, and then captured into a new container image, Docker includes a method for automating this process using a Dockerfile. For this exercise, a Docker ID is required. If you do not have a Docker ID, sign up for one at [Docker Cloud]( https://cloud.docker.com/).
 
 On the container host, create a directory `c:\build`, and in this directory create a file named `Dockerfile`. Note – the file should not have a file extension.
 
@@ -165,7 +92,7 @@ Remove container.
 docker rm -f <container name>
 ```
 
-## 3. Docker Push
+## 2. Docker Push
 
 Docker container images can be stored in a container registry. Once an image is stored in a registry, it can be retrieved for later use across many different container hosts. Docker provides a public registry for storing container images at [Docker Hub](https://hub.docker.com/).
 


### PR DESCRIPTION
Docker has revolutionized container management by adding automation. The documentation seems to advocate that manually creating an image is the first step into Docker. I could not disagree more. New users should be taught to embrace automation and understand the importance of standardization and repeatability. Therefore, I propose to remove the whole section.