### PR TITLE
Clarify differences in isolation=hyperv support for Windows 10 vs Windows Server

### DIFF
--- a/virtualization/windowscontainers/deploy-containers/version-compatibility.md
+++ b/virtualization/windowscontainers/deploy-containers/version-compatibility.md
@@ -27,17 +27,17 @@ As we've been improving the Windows container features, we've had to make some c
     </tr>
     <tr>
         <td style="background-color:#E3F2FD"><b>Windows Server 2016</b><br/>Builds: 14393.*</td>
-        <td>Supported<br/> `process` or `hyperv` isolation</td>
-        <td>Supported<br/> Only `hyperv` isolation</td>
-        <td>Supported<br/> `process` or `hyperv` isolation</td>
-        <td>Supported<br/> Only `hyperv` isolation</td>
+        <td>Supports<br/> `process` or `hyperv` isolation</td>
+        <td>Supports<br/> Only `hyperv` isolation</td>
+        <td>Supports<br/> `process` or `hyperv` isolation</td>
+        <td>Supports<br/> Only `hyperv` isolation</td>
     </tr>
     <tr>
         <td style="background-color:#E3F2FD"><b>Windows Server version 1709</b><br/>Builds 16299.*</td>
         <td>Not supported</td>
         <td>Not supported</td>
-        <td>Supported<br/> `process` or `hyperv` isolation</td>
-        <td>Supported<br/> Only `hyperv` isolation</td>
+        <td>Supports<br/> `process` or `hyperv` isolation</td>
+        <td>Supports<br/> Only `hyperv` isolation</td>
     </tr>
 </table>               
 

--- a/virtualization/windowscontainers/deploy-containers/version-compatibility.md
+++ b/virtualization/windowscontainers/deploy-containers/version-compatibility.md
@@ -15,23 +15,29 @@ As we've been improving the Windows container features, we've had to make some c
 
 <table>
     <tr>
-    <th>Container OS version</th>
-    <th span='2'>Host OS version</th>
+    <th style="background-color:#BBDEFB">Container OS version</th>
+    <th span='4' style="background-color:#DCEDC8">Host OS version</th>
     </tr>
     <tr>
         <td/>
-        <td><b>Windows Server 2016 / Windows 10 1609, 1703</b><br/>Builds: 14393.*</td>
-        <td><b>Windows Server version 1709 / Windows 10 Fall Creators Update</b><br/>Builds 16299.*</td>
+        <td style="background-color:#F1F8E9"><b>Windows Server 2016</b><br/>Builds: 14393.*</td>
+        <td style="background-color:#F1F8E9"><b>Windows 10 1609, 1703</b><br/>Builds: 14393.*, 15063.*</td>
+        <td style="background-color:#F1F8E9"><b>Windows Server version 1709</b><br/>Builds 16299.*</td>
+        <td style="background-color:#F1F8E9"><b>Windows 10 Fall Creators Update</b><br/>Builds 16299.*</td>
     </tr>
     <tr>
-        <td><b>Windows Server 2016 / Windows 10 1609, 1703</b><br/>Builds: 14393.*</td>
+        <td style="background-color:#E3F2FD"><b>Windows Server 2016</b><br/>Builds: 14393.*</td>
         <td>Supported. `process` or `hyperv` isolation</td>
-        <td>Supported. `hyperv` isolation</td>
+        <td>Supported. Only `hyperv` isolation</td>
+        <td>Supported. `process` or `hyperv` isolation</td>
+        <td>Supported. Only `hyperv` isolation</td>
     </tr>
     <tr>
-        <td><b>Windows Server version 1709 / Windows 10 Fall Creators Update</b><br/>Builds 16299.*</td>
+        <td style="background-color:#E3F2FD"><b>Windows Server version 1709</b><br/>Builds 16299.*</td>
+        <td>Not supported</td>
         <td>Not supported</td>
         <td>Supported. `process` or `hyperv` isolation</td>
+        <td>Supported. Only `hyperv` isolation</td>
     </tr>
 </table>               
 

--- a/virtualization/windowscontainers/deploy-containers/version-compatibility.md
+++ b/virtualization/windowscontainers/deploy-containers/version-compatibility.md
@@ -27,17 +27,17 @@ As we've been improving the Windows container features, we've had to make some c
     </tr>
     <tr>
         <td style="background-color:#E3F2FD"><b>Windows Server 2016</b><br/>Builds: 14393.*</td>
-        <td>Supported. `process` or `hyperv` isolation</td>
-        <td>Supported. Only `hyperv` isolation</td>
-        <td>Supported. `process` or `hyperv` isolation</td>
-        <td>Supported. Only `hyperv` isolation</td>
+        <td>Supported<br/> `process` or `hyperv` isolation</td>
+        <td>Supported<br/> Only `hyperv` isolation</td>
+        <td>Supported<br/> `process` or `hyperv` isolation</td>
+        <td>Supported<br/> Only `hyperv` isolation</td>
     </tr>
     <tr>
         <td style="background-color:#E3F2FD"><b>Windows Server version 1709</b><br/>Builds 16299.*</td>
         <td>Not supported</td>
         <td>Not supported</td>
-        <td>Supported. `process` or `hyperv` isolation</td>
-        <td>Supported. Only `hyperv` isolation</td>
+        <td>Supported<br/> `process` or `hyperv` isolation</td>
+        <td>Supported<br/> Only `hyperv` isolation</td>
     </tr>
 </table>               
 


### PR DESCRIPTION
My chart was a bit confusing - there are actually differences between what works on WIndows 10 and Windows Server. Splitting this out to separate columns.