### PR TITLE
Changed order of steps

### DIFF
--- a/virtualization/hyper-v-on-windows/CVE-2017-5715-and-hyper-v-vms.md
+++ b/virtualization/hyper-v-on-windows/CVE-2017-5715-and-hyper-v-vms.md
@@ -3,8 +3,8 @@
 In addition to [this guidance](https://support.microsoft.com/en-us/help/4072698/windows-server-guidance-to-protect-against-the-speculative-execution), the following steps are required to ensure that your virtual machines are protected from CVE-2017-5715 (branch target injection):
 
 1.	Ensure guest virtual machines have access to the updated firmware.
-2.	Perform a cold boot of guest virtual machines.
-3.	Update the guest operating system as required.
+2.	Update the guest operating system as required.
+3.	Perform a cold boot of guest virtual machines.
 
 ## Ensure guest virtual machines have access to the updated firmware
 
@@ -20,17 +20,19 @@ To give virtual machines with a VM version below 8.0 access to the updated firmw
 reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Virtualization" /v MinVmVersionForCpuBasedMitigations /t REG_SZ /d "5.0" /f
 ```
 
+## Update the guest operating system
+
+The guest operating system must be updated take advantage of the new firmware capabilities exposed by Hyper-V.  For Microsoft operating systems, please follow the guidance in [this article](https://support.microsoft.com/en-us/help/4072698/windows-server-guidance-to-protect-against-the-speculative-execution) when updating.
+
+Note: updating the guest operating system can occur at any time in this process.
+
+
 ## Perform a cold boot of the guest
 
 Virtual machines will not see the updated firmware capabilities until they go through a cold boot.  This means the running VMs must completely power off before starting again.  Rebooting from inside the guest operating system is not sufficient.
 
 One way to shut down virtual machines on a host is to use the `Stop-VM` cmdlet.  One way to start virtual machines that are powered off is the `Start-VM` cmdlet.  
 
-## Update the guest operating system
-
-The guest operating system must be updated take advantage of the new firmware capabilities exposed by Hyper-V.  For Microsoft operating systems, please follow the guidance in [this article](https://support.microsoft.com/en-us/help/4072698/windows-server-guidance-to-protect-against-the-speculative-execution) when updating.
-
-Note: updating the guest operating system can occur at any time in this process.
 
 ## Migrating virtual machines between patched and unpatched Hyper-V hosts
 


### PR DESCRIPTION
Moved "install updates" before the cold boot -- while the text mentions that the updates can occur at any time, it seems to make sense to install updates, shut down the VM, and then start it again to pick up the firmware changes