### PR TITLE
Fixed forest/domain name configuration in CredSpec

### DIFF
--- a/windows-server-container-tools/ServiceAccounts/CredentialSpec.psm1
+++ b/windows-server-container-tools/ServiceAccounts/CredentialSpec.psm1
@@ -97,9 +97,9 @@ param(
 
     # Create DomainJoinConfig Object
     $output.DomainJoinConfig = @{}
-    $output.DomainJoinConfig.DnsName = $Domain.Forest
+    $output.DomainJoinConfig.DnsName = $Domain.DNSRoot
     $output.DomainJoinConfig.Guid = $Domain.ObjectGUID
-    $output.DomainJoinConfig.DnsTreeName = $Domain.DNSRoot
+    $output.DomainJoinConfig.DnsTreeName = $Domain.Forest
     $output.DomainJoinConfig.NetBiosName = $Domain.NetBIOSName
     $output.DomainJoinConfig.Sid = $Domain.DomainSID.Value
     $output.DomainJoinConfig.MachineAccountName = $AccountName


### PR DESCRIPTION
The existing behavior for setting the DnsName and DnsTreeName values would only work in a single-domain forest because the values were swapped. This fix corrects the values so that credential specs can be generated in multi-domain forests.