### PR TITLE
Update linux-containers.md

### DIFF
--- a/virtualization/windowscontainers/deploy-containers/linux-containers.md
+++ b/virtualization/windowscontainers/deploy-containers/linux-containers.md
@@ -25,12 +25,12 @@ Ongoing progress in the Moby project can be tracked on [GitHub](https://github.c
 
 These applications all require volume mapping, which has some limitations covered under [Bind mounts](#Bind-mounts). They will not start or run correctly.
 
-- Mysql
-- Postgress
-- Wordpress
+- MySQL
+- PostgreSQL
+- WordPress
 - Jenkins
-- Mariadb
-- Rabbitmq
+- MariaDB
+- RabbitMQ
 
 
 ### Bind mounts


### PR DESCRIPTION
So, either these are product names and should be properly capitalized or they're image names and we should match their names on hub.docker.com.