### PR TITLE
Update WindowsContainerNetworking-LoggingAndCleanupAide.ps1

### DIFF
--- a/windows-server-container-tools/CleanupContainerHostNetworking/WindowsContainerNetworking-LoggingAndCleanupAide.ps1
+++ b/windows-server-container-tools/CleanupContainerHostNetworking/WindowsContainerNetworking-LoggingAndCleanupAide.ps1
@@ -106,7 +106,11 @@ function ForceCleanupSystem
         {
             if ($adapters.HardwareInterface -eq $true)
             {
-                Disable-NetAdapterBinding -Name $adapters.Name -ComponentID vms_pp
+                if ($adapter.Name) {
+                    Disable-NetAdapterBinding -Name $adapters.Name -ComponentID vms_pp
+                } elseif ($adapter.InterfaceDescription) {
+                    Disable-NetAdapterBinding -InterfaceDescription $adapters.InterfaceDescription -ComponentID vms_pp
+                }
             }
         }
 


### PR DESCRIPTION
Fixes errors when adapters without names are present by using interface description when there is no name.

https://github.com/MicrosoftDocs/Virtualization-Documentation/issues/646