### PR TITLE
Add quotation mark

### DIFF
--- a/windows-container-samples/nginx/Dockerfile
+++ b/windows-container-samples/nginx/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM microsoft/windowsservercore
 
-LABEL Description="Nginx" Vendor=Nginx" Version="1.0.13"
+LABEL Description="Nginx" Vendor="Nginx" Version="1.0.13"
 
 RUN powershell -Command \
 	$ErrorActionPreference = 'Stop'; \


### PR DESCRIPTION
Simple fix for the Dockerfile, just add a quotation mark for the vendor label.