### PR TITLE
Added missing -VMName to Set-VMMemory

### DIFF
--- a/virtualization/windowscontainers/deploy-containers/deploy-containers-on-server.md
+++ b/virtualization/windowscontainers/deploy-containers/deploy-containers-on-server.md
@@ -74,7 +74,7 @@ $vm = "<virtual-machine>"
 Set-VMProcessor -VMName $vm -ExposeVirtualizationExtensions $true -Count 2
 
 #disable dynamic memory
-Set-VMMemory $vm -DynamicMemoryEnabled $false
+Set-VMMemory -VMName $vm -DynamicMemoryEnabled $false
 
 #enable mac spoofing
 Get-VMNetworkAdapter -VMName $vm | Set-VMNetworkAdapter -MacAddressSpoofing On


### PR DESCRIPTION
VMName is a mandatory, non positional parameter for Set-VMMemory

PS C:\> Set-VMMemory $vm -DynamicMemoryEnabled $false
Set-VMMemory : Cannot validate argument on parameter 'VMName'. The argument is
null or empty. Provide an argument that is not null or empty, and then try the
command again.
At line:1 char:14
+ Set-VMMemory $vm -DynamicMemoryEnabled $false
+              ~~~
    + CategoryInfo          : InvalidData: (:) [Set-VMMemory], ParameterBindin
   gValidationException
    + FullyQualifiedErrorId : ParameterArgumentValidationError,Microsoft.Hyper
   V.PowerShell.Commands.SetVMMemory