### PR TITLE
Distracting colon in PowerShell

### DIFF
--- a/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v.md
+++ b/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v.md
@@ -38,7 +38,7 @@ Hyper-V is built into Windows as an optional feature -- there is no Hyper-V down
 
 2. Run the following command:
   ```powershell
-  Enable-WindowsOptionalFeature -Online -FeatureName:Microsoft-Hyper-V -All
+  Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All
   ```  
 
   If the command couldn't be found, make sure you're running PowerShell as Administrator.  


### PR DESCRIPTION
The PowerShell syntax has a space between the parameter name and its value, not a colon.

The colon may also work, but still the common convention should be used to avoid confusion.