### PR TITLE
Syntax error fix

### DIFF
--- a/virtualization/hyper-v-on-windows/quick-start/try-hyper-v-powershell.md
+++ b/virtualization/hyper-v-on-windows/quick-start/try-hyper-v-powershell.md
@@ -107,7 +107,7 @@ The following example shows how to create a new virtual machine in the PowerShel
      SwitchName = (Get-VMSwitch).Name[0]
  }
 
- New-VM @VM
+ New-VM $VM
   ```
 
 ## Wrap up and References


### PR DESCRIPTION
This seems to be a typo, but I tested to confirm. 
@VM returns error "A parameter is invalid. No switch can be found by given criteria."
$VM creates the VM as expected with parameters from the the $VM array.