### PR TITLE
Adding link to acs-engine from Kubernetes getting started guide

### DIFF
--- a/virtualization/windowscontainers/kubernetes/getting-started-kubernetes-windows.md
+++ b/virtualization/windowscontainers/kubernetes/getting-started-kubernetes-windows.md
@@ -21,6 +21,8 @@ With the latest release of Kubernetes 1.9 and Windows Server [version 1709](http
 
 This page serves as a guide for getting started joining a brand new Windows node to an existing Linux-based cluster. To start completely from scratch, refer to [this page](./creating-a-linux-master.md) &mdash; one of many resources available for deploying a Kubernetes cluster &mdash; to set a master up from scratch the same way we did.
 
+> If you would like to deploy a cluster on Azure, the open source ACS-Engine tool makes this easy. A step by step [walkthrough](https://github.com/Azure/acs-engine/blob/master/docs/kubernetes/windows.md) is available.
+
 <a name="definitions"></a>
 These are definitions for some terms that are referenced throughout this guide:
 

--- a/virtualization/windowscontainers/kubernetes/getting-started-kubernetes-windows.md
+++ b/virtualization/windowscontainers/kubernetes/getting-started-kubernetes-windows.md
@@ -21,6 +21,7 @@ With the latest release of Kubernetes 1.9 and Windows Server [version 1709](http
 
 This page serves as a guide for getting started joining a brand new Windows node to an existing Linux-based cluster. To start completely from scratch, refer to [this page](./creating-a-linux-master.md) &mdash; one of many resources available for deploying a Kubernetes cluster &mdash; to set a master up from scratch the same way we did.
 
+> [!TIP] 
 > If you would like to deploy a cluster on Azure, the open source ACS-Engine tool makes this easy. A step by step [walkthrough](https://github.com/Azure/acs-engine/blob/master/docs/kubernetes/windows.md) is available.
 
 <a name="definitions"></a>


### PR DESCRIPTION
There's also a guide on how to use acs-engine to deploy Windows. Rather than duplicating those steps, I'd like to link to them.

@gkudra-msft - does this look ok to you? I'm planning to update the samples on the acs-engine page to match the latest Kubernetes & Windows versions next