### PR TITLE
Fixed location of Docker Engine on Windows reference

### DIFF
--- a/virtualization/windowscontainers/manage-containers/container-storage.md
+++ b/virtualization/windowscontainers/manage-containers/container-storage.md
@@ -19,7 +19,7 @@ This is all the files that are built into the container. Every time you `docker 
 
 ### Where layers are stored and how to change it
 
-In a default installation, layers are stored in `C:\ProgramData\docker` and split across the "image" and "windowsfilter" directories. You can change where the layers are stored using the `docker-root` configuration, as demonstrated in the [Docker Engine on Windows](docker/configure_docker_daemon.md) documentation.
+In a default installation, layers are stored in `C:\ProgramData\docker` and split across the "image" and "windowsfilter" directories. You can change where the layers are stored using the `docker-root` configuration, as demonstrated in the [Docker Engine on Windows](../manage-docker/configure_docker_daemon.md) documentation.
 
 > [!NOTE]
 > Only NTFS is supported for layer storage. ReFS is not supported.


### PR DESCRIPTION
Former link was dead, fixed location of Docker Engine on Windows reference