### PR TITLE
Specify network name for start-kubeproxy.ps1.

### DIFF
--- a/virtualization/windowscontainers/kubernetes/getting-started-kubernetes-windows.md
+++ b/virtualization/windowscontainers/kubernetes/getting-started-kubernetes-windows.md
@@ -157,7 +157,7 @@ The node is now ready to join the cluster. In two separate, *elevated* PowerShel
 
 ```powershell
 ./start-kubelet.ps1 -ClusterCidr 192.168.0.0/16
-./start-kubeproxy.ps1
+./start-kubeproxy.ps1 -NetworkName l2bridge
 ```
 
 The Windows node will be visible from the Linux master under `kubectl get nodes` within a minute!


### PR DESCRIPTION
The default network name used in start-kubeproxy.ps1, "cbr0", does not
match the name of the network that start-kubelet.ps1 creates,
"l2bridge". This can be confirmed by running Get-HnsNetwork after
running start-kubelet.ps1.

When the network name does not match start-kubeproxy.ps1 fails with:
E0609 01:20:44.426633    1496 proxier.go:646] Network cbr0 not found
F0609 01:20:44.451041    1496 proxier.go:474] Unable to find Hns Network
specified by cbr0. Please check environment variable KUBE_NETWORK