### PR TITLE
Updated the Revision C link

### DIFF
--- a/virtualization/hyper-v-on-windows/reference/tlfs.md
+++ b/virtualization/hyper-v-on-windows/reference/tlfs.md
@@ -21,7 +21,7 @@ The Hyper-V Hypervisor Top-Level Functional Specification (TLFS) describes the h
 #### Download
 Release | Document
 --- | ---
-Windows Server 2016 (Revision C) | [Hypervisor Top Level Functional Specification v5.0c.pdf](https://github.com/MicrosoftDocs/Virtualization-Documentation/blob/live/tlfs/Hypervisor%20Top%20Level%20Functional%20Specification%20v5.0C.pdf)
+Windows Server 2016 (Revision C) | [Hypervisor Top Level Functional Specification v5.0c.pdf](https://github.com/MicrosoftDocs/Virtualization-Documentation/raw/live/tlfs/Hypervisor%20Top%20Level%20Functional%20Specification%20v5.0C.pdf)
 Windows Server 2012 R2 (Revision B) | [Hypervisor Top Level Functional Specification v4.0b.pdf](https://github.com/Microsoft/Virtualization-Documentation/raw/master/tlfs/Hypervisor%20Top%20Level%20Functional%20Specification%20v4.0b.pdf)
 Windows Server 2012 | [Hypervisor Top Level Functional Specification v3.0.pdf](https://github.com/Microsoft/Virtualization-Documentation/raw/master/tlfs/Hypervisor%20Top%20Level%20Functional%20Specification%20v3.0.pdf)
 Windows Server 2008 R2 | [Hypervisor Top Level Functional Specification v2.0.pdf](https://github.com/Microsoft/Virtualization-Documentation/raw/master/tlfs/Hypervisor%20Top%20Level%20Functional%20Specification%20v2.0.pdf)


### PR DESCRIPTION
Replaced the Revision C link by the "/raw" github link to force the browser to download the file. Because on the mobile version github can't show you the PDF preview in the browser + to be consistent with the other revision links that are already using the /raw links.