### PR TITLE
Updated the Standard output of the container

### DIFF
--- a/virtualization/windowscontainers/quick-start/quick-start-windows-server.md
+++ b/virtualization/windowscontainers/quick-start/quick-start-windows-server.md
@@ -138,7 +138,7 @@ The container starts, prints the hello world message, and then exits.
 
 
 **Environment**
-Platform: .NET Core 1.0
+Platform: .NET Core 2.0
 OS: Microsoft Windows 10.0.14393
 ```
 


### PR DESCRIPTION
Since the specified tag is dotnetapp-nanoserver and the latest .NET Core version is 2.0, I've updated the Standard output to match the correct current output of the container, namely 2.0.