### PR TITLE
Dropped a '>'

### DIFF
--- a/virtualization/windowscontainers/manage-docker/manage-windows-dockerfile.md
+++ b/virtualization/windowscontainers/manage-docker/manage-windows-dockerfile.md
@@ -93,7 +93,7 @@ The RUN instruction takes a format of:
 ```
 # exec form
 
-RUN ["<executable", "<param 1>", "<param 2>"]
+RUN ["<executable>", "<param 1>", "<param 2>"]
 
 # shell form
 


### PR DESCRIPTION
A bit of proofreading: added a '>' where one appeared to be missing.