### PR TITLE
Typo fix

### DIFF
--- a/virtualization/hyper-v-on-windows/about/index.md
+++ b/virtualization/hyper-v-on-windows/about/index.md
@@ -31,7 +31,7 @@ Virtualization allows you to:
 
 ## System requirements
 
-Hyper-V is available on 64-bit versions of Windows 10 Pro, Enterprise, and Education in Windows 8 and later.  It is not available on Windows Home edition.
+Hyper-V is available on 64-bit versions of Windows 10 Pro, Enterprise, and Education. It is not available on the Home edition.
 
 > Upgrade from Windows 10 Home edition to Windows 10 Pro by opening **Settings** > **Update and Security** > **Activation**. Here you can visit the store and purchase an upgrade.
 

--- a/virtualization/hyper-v-on-windows/about/index.md
+++ b/virtualization/hyper-v-on-windows/about/index.md
@@ -31,9 +31,9 @@ Virtualization allows you to:
 
 ## System requirements
 
-Hyper-V is available on 64-bit versions of Windows Professional, Enterprise, and Education in Windows 8 and later.  It is not available on Windows Home edition.
+Hyper-V is available on 64-bit versions of Windows 10 Pro, Enterprise, and Education in Windows 8 and later.  It is not available on Windows Home edition.
 
-> Upgrade from Windows 10 Home edition to Windows 10 Professional by opening **Settings** > **Update and Security** > **Activation**. Here you can visit the store and purchase an upgrade.
+> Upgrade from Windows 10 Home edition to Windows 10 Pro by opening **Settings** > **Update and Security** > **Activation**. Here you can visit the store and purchase an upgrade.
 
 Most computers will run Hyper-V however each virtual machine is a completely seperate operating system.  You can generally run one or more virtual machines on a computer with 4GB of RAM, though you'll need more resources for additional virtual machines or to install and run resource intense software like games, video editing, or engineering design software.
 

--- a/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v.md
+++ b/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v.md
@@ -18,14 +18,14 @@ Hyper-V can be enabled in many ways including using the Windows 10 control panel
 
 ## Check Requirements
 
-* Windows 10 Enterprise, Professional, or Education
+* Windows 10 Enterprise, Pro, or Education
 * 64-bit Processor with Second Level Address Translation (SLAT).
 * CPU support for VM Monitor Mode Extension (VT-c on Intel CPU's).
 * Minimum of 4 GB memory.
 
 The Hyper-V role **cannot** be installed on Windows 10 Home.
 
-Upgrade from Windows 10 Home edition to Windows 10 Professional by opening up **Settings** > **Update and Security** > **Activation**.
+Upgrade from Windows 10 Home edition to Windows 10 Pro by opening up **Settings** > **Update and Security** > **Activation**.
 
 For more information and troubleshooting, see [Windows 10 Hyper-V System Requirements](../reference/hyper-v-requirements.md).
 

--- a/virtualization/hyper-v-on-windows/reference/hyper-v-requirements.md
+++ b/virtualization/hyper-v-on-windows/reference/hyper-v-requirements.md
@@ -12,7 +12,7 @@ ms.assetid: 6e5e6b01-7a9d-4123-8cc7-f986e10cd372
 
 # Windows 10 Hyper-V System Requirements
 
-Hyper-V is available in 64-bit version of Windows Professional, Enterprise, and Education editions of Windows 8 and greater.  Hyper-V requires Second Level Address Translation (SLAT) -- present in the current generation of 64-bit processors by Intel and AMD.
+Hyper-V is available in 64-bit version of Windows 10 Pro, Enterprise, and Education. Hyper-V requires Second Level Address Translation (SLAT) -- present in the current generation of 64-bit processors by Intel and AMD.
 
 You can run 3 or 4 basic virtual machines on a host that has 4GB of RAM, though you'll need more resources for more virtual machines. On the other end of the spectrum, you can also create large virtual machines with 32 processors and 512GB RAM, depending on your physical hardware.
 
@@ -21,7 +21,7 @@ You can run 3 or 4 basic virtual machines on a host that has 4GB of RAM, though 
 The Hyper-V role can be enabled on these versions of Windows 10:
 
 - Windows 10 Enterprise
-- Windows 10 Professional
+- Windows 10 Pro
 - Windows 10 Education
 
 The Hyper-V role **cannot** be installed on:
@@ -30,7 +30,7 @@ The Hyper-V role **cannot** be installed on:
 - Windows 10 Mobile
 - Windows 10 Mobile Enterprise
 
->Windows 10 Home edition can be upgraded to Windows 10 Professional. To do so open up **Settings** > **Update and Security** > **Activation**. Here you can visit the store and purchase an upgrade.
+>Windows 10 Home edition can be upgraded to Windows 10 Pro. To do so open up **Settings** > **Update and Security** > **Activation**. Here you can visit the store and purchase an upgrade.
 
 ## Hardware Requirements
 


### PR DESCRIPTION
Typo fix. It is called "Windows 10 Pro", not "Windows 10 Professional". Also, Windows 8 did not have an "Education" edition or "Home" edition. (The equivalent to "Home" edition in Windows 8 had not name.) Finally, these page are supposedly exclusive to Windows 10; there is no call fixing Windows 8 talk.