### PR TITLE
Update the Dockerfile MAINTAINED instruction.

### DIFF
--- a/virtualization/windowscontainers/manage-docker/manage-windows-dockerfile.md
+++ b/virtualization/windowscontainers/manage-docker/manage-windows-dockerfile.md
@@ -44,7 +44,7 @@ In its most basic form, a Dockerfile can be very simple. The following example c
 FROM microsoft/windowsservercore
 
 # Metadata indicating an image maintainer.
-MAINTAINER jshelton@contoso.com
+LABEL maintainer="jshelton@contoso.com"
 
 # Uses dism.exe to install the IIS role.
 RUN dism.exe /online /enable-feature /all /featurename:iis-webserver /NoRestart


### PR DESCRIPTION
The MAINTAINED instruction is deprecated. It's preferred that you use the LABEL instruction to set a label for maintainer. This allows the information to be obtained via "docker inspect" and to be filtered using "-f".