### PR TITLE
update build script for generating k8s windows binaries

### DIFF
--- a/virtualization/windowscontainers/kubernetes/compiling-kubernetes-binaries.md
+++ b/virtualization/windowscontainers/kubernetes/compiling-kubernetes-binaries.md
@@ -86,9 +86,9 @@ git clone https://github.com/kubernetes/kubernetes.git ${SRC_DIR}
 
 cd ${SRC_DIR}
 git checkout tags/v1.9.1
-KUBE_BUILD_PLATFORMS=linux/amd64   build/run.sh make WHAT=cmd/kubelet
-KUBE_BUILD_PLATFORMS=windows/amd64 build/run.sh make WHAT=cmd/kubelet 
-KUBE_BUILD_PLATFORMS=windows/amd64 build/run.sh make WHAT=cmd/kube-proxy 
+build/run.sh make kubectl KUBE_BUILD_PLATFORMS=windows/amd64
+build/run.sh make kubelet KUBE_BUILD_PLATFORMS=windows/amd64
+build/run.sh make kube-proxy KUBE_BUILD_PLATFORMS=windows/amd64
 cp _output/dockerized/bin/windows/amd64/kube*.exe ${DIST_DIR}
 
 ls ${DIST_DIR}


### PR DESCRIPTION
This PR updates the build script for generating Kubernetes windows binaries:

- the previous cmd didn't work ( KUBE_BUILD_PLATFORMS=windows/amd64 wasn't passed to build container as expected )

- sync with the latest build script sample documented in https://github.com/kubernetes/kubernetes/blob/master/build/README.md
