### PR TITLE
Update Blogengine.net download url

### DIFF
--- a/windows-container-samples/ASP-NET-Blog-Application/web/Dockerfile
+++ b/windows-container-samples/ASP-NET-Blog-Application/web/Dockerfile
@@ -7,7 +7,8 @@ RUN powershell add-windowsfeature web-asp-net45
 # # Download and extract BlogEngine.NET project files
 RUN powershell -Command \
     $ErrorActionPreference = 'Stop'; \
-	Invoke-WebRequest -Method Get -Uri https://blogengine.codeplex.com/downloads/get/1566660 -OutFile c:\BlogEngineNETSrc.zip ; \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Method Get -Uri https://github.com/rxtur/BlogEngine.NET/releases/download/v3.3.6.0/3360.zip -OutFile c:\BlogEngineNETSrc.zip ; \
 	Expand-Archive -Path c:\BlogEngineNETSrc.zip -DestinationPath c:\inetpub\wwwroot\blogengine ; \
 	Remove-Item c:\BlogEngineNETSrc.zip -Force
 


### PR DESCRIPTION
Update Blogengine.net download url as old one is a redirect that does not point to binaries.