### PR TITLE
Clarify that Skipping foreign layer is success

### DIFF
--- a/virtualization/windowscontainers/quick-start/quick-start-images.md
+++ b/virtualization/windowscontainers/quick-start/quick-start-images.md
@@ -125,6 +125,8 @@ Once logged in, the container image can be pushed to Docker Hub. To do so, use t
 docker push <user>/iis-dockerfile
 ```
 
+As Docker pushes each layer up to Docker Hub, docker will skip layers that already exist in the Docker Hub, or in other registries (foreign layers).  For example, recent versions of Windows Server Core that are hosted in the Microsoft Container Registry, or layers from a private corporate registry, would be skipped, and not pushed onto Docker Hub.
+
 The container image can now be downloaded from Docker Hub onto any Windows container host using `docker pull`. For this tutorial, we will delete the existing image, and then pull it down from Docker Hub. 
 
 ```console


### PR DESCRIPTION
Windows Server Core images are now hosted on MCR and so are "foreign layers" to Docker hub.
For a new Docker user trying to use this quick start (like me) this seems like an error.
Adding a clarification that "foreign" layers are expected.