### PR TITLE
Fix problem with New-VM script example.

### DIFF
--- a/virtualization/hyper-v-on-windows/quick-start/try-hyper-v-powershell.md
+++ b/virtualization/hyper-v-on-windows/quick-start/try-hyper-v-powershell.md
@@ -104,10 +104,10 @@ The following example shows how to create a new virtual machine in the PowerShel
      NewVHDSizeBytes = 53687091200
      BootDevice = "VHD"
      Path = "C:\Virtual Machines\$VMName"
-     SwitchName = (Get-VMSwitch).Name[0]
+     SwitchName = (Get-VMSwitch).Name
  }
 
- New-VM $VM
+ New-VM @VM
   ```
 
 ## Wrap up and References


### PR DESCRIPTION
Seems there was a few problems with this example.

Firstly, the hash table was being passed with `$VM` so you'd get a default VM with the name `System.Collections.HashTable`.

Second, the switch name being found was `D` instead of `Default` since we were indexing in.