### PR TITLE
Add '-Type' parameter to prevent wrong registry value kind.

### DIFF
--- a/hyperv-tools/vmgallery/add-source.ps1
+++ b/hyperv-tools/vmgallery/add-source.ps1
@@ -13,7 +13,7 @@ $key = get-item $galleryRegPath
 $values = $key.GetValue($galleryRegKey)
 $values += $newURI
 
-Set-ItemProperty $galleryRegPath $galleryRegKey $values
+Set-ItemProperty -Path $galleryRegPath -Name $galleryRegKey -Value $values -Type MultiString 
 
 Write-Host ""
 Write-Host "Successfully added $newURI to $galleryRegKey"

--- a/hyperv-tools/vmgallery/reset-sources.ps1
+++ b/hyperv-tools/vmgallery/reset-sources.ps1
@@ -2,7 +2,7 @@ $galleryRegPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Virtualiza
 $galleryRegKey = "GalleryLocations"
 $defaultLocations = "https://go.microsoft.com/fwlink/?linkid=851584"
 
-Set-ItemProperty -Path $galleryregpath -Name $galleryRegKey -Value $defaultLocations
+Set-ItemProperty -Path $galleryregpath -Name $galleryRegKey -Value $defaultLocations -Type MultiString 
 
 Write-Host "Successfully reset $galleryRegKey"
 Write-Host ""


### PR DESCRIPTION
In some case, type of GalleryLocations value was REG_SZ.
It should be REG_MULTI_SZ for multiple values such as  GalleryLocations.
Added -Type dynamic parameter into each Set-ItemProperty calls.

The -Type parameter is documented below
https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_registry_provider?view=powershell-6#dynamic-parameters