### PR TITLE
Correcting SSL / TLS error when building image

### DIFF
--- a/windows-container-samples/apache-http/Dockerfile
+++ b/windows-container-samples/apache-http/Dockerfile
@@ -7,12 +7,14 @@ LABEL Description="Apache" Vendor="Apache Software Foundation" Version="2.4.23"
 
 RUN powershell -Command \
 	$ErrorActionPreference = 'Stop'; \
-	Invoke-WebRequest -Method Get -Uri https://www.apachelounge.com/download/VC14/binaries/httpd-2.4.23-win64-VC14.zip -OutFile c:\apache.zip ; \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Method Get -Uri https://home.apache.org/~steffenal/VC14/binaries/httpd-2.4.38-win64-VC14.zip -OutFile c:\apache.zip ; \
 	Expand-Archive -Path c:\apache.zip -DestinationPath c:\ ; \
 	Remove-Item c:\apache.zip -Force
 
 RUN powershell -Command \
 	$ErrorActionPreference = 'Stop'; \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Method Get -Uri "https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x64.exe" -OutFile c:\vc_redist.x64.exe ; \
 	start-Process c:\vc_redist.x64.exe -ArgumentList '/quiet' -Wait ; \
 	Remove-Item c:\vc_redist.x64.exe -Force


### PR DESCRIPTION
This pull request corrects an SSL / TLS error when building the image.

When building the image, Powershell `Invoke-WebRequest` command is used to download apache httpd binaries and .Net package. Without TLS set, the command fails.
Adding a security protocol to the  `Invoke-WebRequest` command solved the issue.

I also correct the URI to the apache httpd binaires which has moved from the previous URI.
