### PR TITLE
Docker for Windows is now Docker Desktop

### DIFF
--- a/virtualization/windowscontainers/quick-start/quick-start-windows-10-linux.md
+++ b/virtualization/windowscontainers/quick-start/quick-start-windows-10-linux.md
@@ -20,8 +20,8 @@ The exercise will walk through creating and running Linux containers on Windows 
 
 In this quick start you will accomplish:
 
-1. Installed Docker for Windows
-2. Run a simple Linux container using Linux Containers on Windows (LCOW)
+1. Installing Docker for Windows
+2. Running a simple Linux container using Linux Containers on Windows (LCOW)
 
 This quick start is specific to Windows 10. Additional quick start documentation can be found in the table of contents on the left-hand side of this page.
 

--- a/virtualization/windowscontainers/quick-start/quick-start-windows-10-linux.md
+++ b/virtualization/windowscontainers/quick-start/quick-start-windows-10-linux.md
@@ -20,7 +20,7 @@ The exercise will walk through creating and running Linux containers on Windows 
 
 In this quick start you will accomplish:
 
-1. Installing Docker for Windows
+1. Installing Docker Desktop
 2. Running a simple Linux container using Linux Containers on Windows (LCOW)
 
 This quick start is specific to Windows 10. Additional quick start documentation can be found in the table of contents on the left-hand side of this page.
@@ -34,9 +34,9 @@ Please make sure you meet the following requirements:
 ***Hyper-V isolation:***
 Linux Containers on Windows require Hyper-V isolation on Windows 10 in order to provide developers with the the appropriate Linux kernel to run the container. More about Hyper-V isolation can be found on the [About Windows container](../about/index.md) page.
 
-## Install Docker for Windows
+## Install Docker Desktop
 
-Download [Docker for Windows](https://store.docker.com/editions/community/docker-ce-desktop-windows) and run the installer (You will be required to login. Create an account if you don't have one already). [Detailed installation instructions](https://docs.docker.com/docker-for-windows/install) are available in the Docker documentation.
+Download [Docker Desktop](https://store.docker.com/editions/community/docker-ce-desktop-windows) and run the installer (You will be required to login. Create an account if you don't have one already). [Detailed installation instructions](https://docs.docker.com/docker-for-windows/install) are available in the Docker documentation.
 
 > If you already have Docker installed, make sure you have version 18.02 or later to support LCOW. Check by running `docker -v` or checking *About Docker*.
 

--- a/virtualization/windowscontainers/quick-start/quick-start-windows-10.md
+++ b/virtualization/windowscontainers/quick-start/quick-start-windows-10.md
@@ -20,7 +20,7 @@ The exercise will walk through creating and running Windows containers on Window
 
 In this quick start you will accomplish:
 
-1. Installing Docker for Windows
+1. Installing Docker Desktop
 2. Running a simple Windows container
 
 This quick start is specific to Windows 10. Additional quick start documentation can be found in the table of contents on the left-hand side of this page.
@@ -36,13 +36,13 @@ Windows Server Containers require Hyper-V isolation on Windows 10 in order to pr
 > [!NOTE]
 > In the release of Windows October Update 2018, we no longer disallow users from running a Windows container in process-isolation mode on Windows 10 Enterprise or Professional for dev/test purposes. See the [FAQ](../about/faq.md) to learn more.
 
-## Install Docker for Windows
+## Install Docker Desktop
 
-Download [Docker for Windows](https://store.docker.com/editions/community/docker-ce-desktop-windows) and run the installer (You will be required to login. Create an account if you don't have one already). [Detailed installation instructions](https://docs.docker.com/docker-for-windows/install) are available in the Docker documentation.
+Download [Docker Desktop](https://store.docker.com/editions/community/docker-ce-desktop-windows) and run the installer (You will be required to login. Create an account if you don't have one already). [Detailed installation instructions](https://docs.docker.com/docker-for-windows/install) are available in the Docker documentation.
 
 ## Switch to Windows containers
 
-After installation Docker for Windows defaults to running Linux containers. Switch to Windows containers using either the Docker tray-menu or by running the following command in a PowerShell prompt:
+After installation Docker Desktop defaults to running Linux containers. Switch to Windows containers using either the Docker tray-menu or by running the following command in a PowerShell prompt:
 
 ```console
 & $Env:ProgramFiles\Docker\Docker\DockerCli.exe -SwitchDaemon .


### PR DESCRIPTION
This is a pull request from a Docker employee.
Note that our documentation uses both Docker Desktop and Docker Desktop for Windows. We prefer the former where the OS is clear from context, but the latter would be OK too.

Signed-off-by: Stephen Turner <stephen.turner@docker.com>
