### PR TITLE
Fix some windows-container-samples

### DIFF
--- a/windows-container-samples/Django/Dockerfile
+++ b/windows-container-samples/Django/Dockerfile
@@ -1,10 +1,10 @@
 # This dockerfile utilizes components licensed by their respective owners/authors.
 # Prior to utilizing this file or resulting images please review the respective licenses at: https://github.com/django/django/blob/master/LICENSE
 
-FROM microsoft/python
+FROM python
 
-LABEL Description="Django" Vendor="Django Software Foundation" Version="1.8.6"
+LABEL Description="Django" Vendor="Django Software Foundation" Version="2.2"
 
-RUN ["pip", "install", "Django==1.8.6"]
+RUN ["pip", "install", "Django==2.2"]
 
 CMD ["django-admin --version"]

--- a/windows-container-samples/Django/README.md
+++ b/windows-container-samples/Django/README.md
@@ -1,6 +1,6 @@
 # Description:
 
-Creates an image containing Apache 1.8.6.
+Creates an image containing Django 2.2.
 
 The microsoft/python is used as the base image.
 
@@ -20,7 +20,7 @@ docker build -t django:latest .
 
 **Docker Run** 
 
-This will start a container, display the Django version, and then exit.  Modify the Dockerfile appropriately for application use. 
+This will start a container, display the Django version, and then exit. Modify the Dockerfile appropriately for application use. 
 
 ```
 docker run -it 80:80 django
@@ -31,11 +31,11 @@ docker run -it 80:80 django
 # This dockerfile utilizes components licensed by their respective owners/authors.
 # Prior to utilizing this file or resulting images please review the respective licenses at: https://github.com/django/django/blob/master/LICENSE
 
-FROM microsoft/python
+FROM python
 
-LABEL Description="Django" Vendor="Django Software Foundation" Version="1.8.6"
+LABEL Description="Django" Vendor="Django Software Foundation" Version="2.2"
 
-RUN ["pip", "install", "Django==1.8.6"]
+RUN ["pip", "install", "Django==2.2"]
 
 CMD ["django-admin --version"]
 ```

--- a/windows-container-samples/apache-http-php/Dockerfile
+++ b/windows-container-samples/apache-http-php/Dockerfile
@@ -3,23 +3,26 @@
 
 FROM microsoft/windowsservercore
 
-LABEL Description="Apache-PHP" Vendor1="Apache Software Foundation" Version1="2.4.20" Vendor2="The PHP Group" Version2="5.5.36"
+LABEL Description="Apache-PHP" Vendor1="Apache Software Foundation" Version1="2.4.38" Vendor2="The PHP Group" Version2="5.6.40"
 
 RUN powershell -Command \
 	$ErrorActionPreference = 'Stop'; \
-	Invoke-WebRequest -Method Get -Uri https://www.apachelounge.com/download/VC11/binaries/httpd-2.4.20-win32-VC11.zip -OutFile c:\apache.zip ; \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Method Get -Uri https://home.apache.org/~steffenal/VC11/binaries/httpd-2.4.38-win32-VC11.zip -OutFile c:\apache.zip ; \
 	Expand-Archive -Path c:\apache.zip -DestinationPath c:\ ; \
 	Remove-Item c:\apache.zip -Force
 
 RUN powershell -Command \
 	$ErrorActionPreference = 'Stop'; \
-   	Invoke-WebRequest -Method Get -Uri "https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x86.exe" -OutFile c:\vcredist_x86.exe ; \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Method Get -Uri https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x86.exe -OutFile c:\vcredist_x86.exe ; \
    	start-Process c:\vcredist_x86.exe -ArgumentList '/quiet' -Wait ; \
    	Remove-Item c:\vcredist_x86.exe -Force
 
 RUN powershell -Command \
 	$ErrorActionPreference = 'Stop'; \
-	Invoke-WebRequest -Method Get -Uri http://windows.php.net/downloads/releases/php-5.5.36-Win32-VC11-x86.zip -OutFile c:\php.zip ; \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Method Get -Uri https://windows.php.net/downloads/releases/php-5.6.40-Win32-VC11-x86.zip -OutFile c:\php.zip ; \
 	Expand-Archive -Path c:\php.zip -DestinationPath c:\php ; \
 	Remove-Item c:\php.zip -Force
 

--- a/windows-container-samples/apache-http-php/README.md
+++ b/windows-container-samples/apache-http-php/README.md
@@ -1,6 +1,6 @@
 # Description:
 
-Creates an image containing Apache 2.4.18 for Windows, PHP and the required Visual Studio redistributable package. Additionally, a sample Apache configuration file (included in the repo) is copied into the Apache folder, and a sample PHP site created (to validate functionality). This dockerfile is for demonstration purposes and may require modification for production use. 
+Creates an image containing Apache 2.4.38 for Windows, PHP and the required Visual Studio redistributable package. Additionally, a sample Apache configuration file (included in the repo) is copied into the Apache folder, and a sample PHP site created (to validate functionality). This dockerfile is for demonstration purposes and may require modification for production use. 
 
 # Environment:
 
@@ -28,23 +28,26 @@ docker run -d -p 80:80 apache-http-php
 
 FROM microsoft/windowsservercore
 
-LABEL Description="Apache-PHP" Vendor1="Apache Software Foundation" Version1="2.4.18" Vendor2="The PHP Group" Version2="5.5.33"
+LABEL Description="Apache-PHP" Vendor1="Apache Software Foundation" Version1="2.4.38" Vendor2="The PHP Group" Version2="5.6.40"
 
 RUN powershell -Command \
 	$ErrorActionPreference = 'Stop'; \
-	Invoke-WebRequest -Method Get -Uri https://www.apachelounge.com/download/VC11/binaries/httpd-2.4.18-win32-VC11.zip -OutFile c:\apache.zip ; \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Method Get -Uri https://home.apache.org/~steffenal/VC11/binaries/httpd-2.4.38-win32-VC11.zip -OutFile c:\apache.zip ; \
 	Expand-Archive -Path c:\apache.zip -DestinationPath c:\ ; \
 	Remove-Item c:\apache.zip -Force
 
 RUN powershell -Command \
 	$ErrorActionPreference = 'Stop'; \
-   	Invoke-WebRequest -Method Get -Uri "https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x86.exe" -OutFile c:\vcredist_x86.exe ; \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Method Get -Uri https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x86.exe -OutFile c:\vcredist_x86.exe ; \
    	start-Process c:\vcredist_x86.exe -ArgumentList '/quiet' -Wait ; \
    	Remove-Item c:\vcredist_x86.exe -Force
 
 RUN powershell -Command \
 	$ErrorActionPreference = 'Stop'; \
-	Invoke-WebRequest -Method Get -Uri http://windows.php.net/downloads/releases/php-5.5.33-Win32-VC11-x86.zip -OutFile c:\php.zip ; \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Method Get -Uri https://windows.php.net/downloads/releases/php-5.6.40-Win32-VC11-x86.zip -OutFile c:\php.zip ; \
 	Expand-Archive -Path c:\php.zip -DestinationPath c:\php ; \
 	Remove-Item c:\php.zip -Force
 

--- a/windows-container-samples/python-django/Dockerfile
+++ b/windows-container-samples/python-django/Dockerfile
@@ -3,16 +3,17 @@
 
 FROM microsoft/windowsservercore
 
-LABEL Description="Python" Vendor="Python Software Foundation" Version="3.5.1"
+LABEL Description="Python" Vendor="Python Software Foundation" Version="3.7.3"
 
 RUN powershell.exe -Command \
 	$ErrorActionPreference = 'Stop'; \
- 	Invoke-WebRequest https://www.python.org/ftp/python/3.5.1/python-3.5.1.exe -OutFile c:\python-3.5.1.exe ; \
-	start-Process  c:\python-3.5.1.exe -ArgumentList '/quiet InstallAllUsers=1 PrependPath=1' -Wait  ; \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest https://www.python.org/ftp/python/3.7.3/python-3.7.3.exe -OutFile c:\python-3.7.3.exe ; \
+	start-Process  c:\python-3.7.3.exe -ArgumentList '/quiet InstallAllUsers=1 PrependPath=1' -Wait  ; \
 	Sleep 60 ; \
-	Remove-Item c:\python-3.5.1.exe -Force
+	Remove-Item c:\python-3.7.3.exe -Force
 
-RUN ["pip", "install", "Django==1.8.6"]
+RUN ["pip", "install", "Django==2.2"]
 
 CMD ["django-admin --version"]
-	
+

--- a/windows-container-samples/python-django/README.md
+++ b/windows-container-samples/python-django/README.md
@@ -1,6 +1,6 @@
 # Description:
 
-Creates an image containing Python 3.5.1 and Django 1.8.6.
+Creates an image containing Python 3.7.3 and Django 2.2.
 
 This dockerfile is for demonstration purposes and may require modification for production use. 
 
@@ -31,19 +31,18 @@ docker run -it python-django
 
 FROM microsoft/windowsservercore
 
-LABEL Description="Python" Vendor="Python Software Foundation" Version="3.5.1"
+LABEL Description="Python" Vendor="Python Software Foundation" Version="3.7.3"
 
 RUN powershell.exe -Command \
 	$ErrorActionPreference = 'Stop'; \
- 	Invoke-WebRequest https://www.python.org/ftp/python/3.5.1/python-3.5.1.exe -OutFile c:\python-3.5.1.exe ; \
-	start-Process  c:\python-3.5.1.exe -ArgumentList '/quiet InstallAllUsers=1 PrependPath=1' -Wait  ; \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest https://www.python.org/ftp/python/3.7.3/python-3.7.3.exe -OutFile c:\python-3.7.3.exe ; \
+	start-Process  c:\python-3.7.3.exe -ArgumentList '/quiet InstallAllUsers=1 PrependPath=1' -Wait  ; \
 	Sleep 60 ; \
-	Remove-Item c:\python-3.5.1.exe -Force
+	Remove-Item c:\python-3.7.3.exe -Force
 
-RUN ["pip", "install", "Django==1.8.6"]
+RUN ["pip", "install", "Django==2.2"]
 
 CMD ["django-admin --version"]
-		
 ```
-
 

--- a/windows-container-samples/python/Dockerfile
+++ b/windows-container-samples/python/Dockerfile
@@ -3,13 +3,14 @@
 
 FROM microsoft/windowsservercore
 
-LABEL Description="Python" Vendor="Python Software Foundation" Version="3.5.1"
+LABEL Description="Python" Vendor="Python Software Foundation" Version="3.7.3"
 
 RUN powershell.exe -Command \
     $ErrorActionPreference = 'Stop'; \
-    wget https://www.python.org/ftp/python/3.5.1/python-3.5.1.exe -OutFile c:\python-3.5.1.exe ; \
-    Start-Process c:\python-3.5.1.exe -ArgumentList '/quiet InstallAllUsers=1 PrependPath=1' -Wait ; \
-    Remove-Item c:\python-3.5.1.exe -Force
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+    wget https://www.python.org/ftp/python/3.7.3/python-3.7.3.exe -OutFile c:\python-3.7.3.exe ; \
+    Start-Process c:\python-3.7.3.exe -ArgumentList '/quiet InstallAllUsers=1 PrependPath=1' -Wait ; \
+    Remove-Item c:\python-3.7.3.exe -Force
 
 RUN echo print("Hello World!") > c:\hello.py
 

--- a/windows-container-samples/python/README.md
+++ b/windows-container-samples/python/README.md
@@ -1,6 +1,6 @@
 # Description:
 
-Creates an image with containing Python 3.5.1. Also included is a ‘World Script’ to test functionality.
+Creates an image with containing Python 3.7.3. Also included is a ‘World Script’ to test functionality.
 
 This dockerfile is for demonstration purposes and may require modification for production use. 
 
@@ -31,18 +31,18 @@ docker run -it python
 
 FROM microsoft/windowsservercore
 
-LABEL Description="Python" Vendor="Python Software Foundation" Version="3.5.1"
+LABEL Description="Python" Vendor="Python Software Foundation" Version="3.7.3"
 
 RUN powershell.exe -Command \
     $ErrorActionPreference = 'Stop'; \
-    wget https://www.python.org/ftp/python/3.5.1/python-3.5.1.exe -OutFile c:\python-3.5.1.exe ; \
-    Start-Process c:\python-3.5.1.exe -ArgumentList '/quiet InstallAllUsers=1 PrependPath=1' -Wait ; \
-    Remove-Item c:\python-3.5.1.exe -Force
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+    wget https://www.python.org/ftp/python/3.7.3/python-3.7.3.exe -OutFile c:\python-3.7.3.exe ; \
+    Start-Process c:\python-3.7.3.exe -ArgumentList '/quiet InstallAllUsers=1 PrependPath=1' -Wait ; \
+    Remove-Item c:\python-3.7.3.exe -Force
 
 RUN echo print("Hello World!") > c:\hello.py
 
 CMD ["py", "c:/hello.py"]
-		
 ```
 
 

--- a/windows-container-samples/sqlite/Dockerfile
+++ b/windows-container-samples/sqlite/Dockerfile
@@ -5,21 +5,23 @@
 
 FROM microsoft/windowsservercore
 
-LABEL Description="SQLite" Vendor="SQLite" Version="3.14.2"
+LABEL Description="SQLite" Vendor="SQLite" Version="3.27.2"
 
 RUN powershell -Command \
 	$ErrorActionPreference = 'Stop'; \
-	Invoke-WebRequest -Method Get -Uri https://www.sqlite.org/2016/sqlite-dll-win64-x64-3140200.zip -OutFile c:\sqlite-dll-win64-x64-3120000.zip ; \
-	Expand-Archive -Path c:\sqlite-dll-win64-x64-3120000.zip -DestinationPath c:\sqlite ; \
-	Remove-Item c:\sqlite-dll-win64-x64-3120000.zip -Force
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Method Get -Uri https://www.sqlite.org/2019/sqlite-dll-win64-x64-3270200.zip -OutFile c:\sqlite-dll-win64-x64.zip ; \
+	Expand-Archive -Path c:\sqlite-dll-win64-x64.zip -DestinationPath c:\sqlite ; \
+	Remove-Item c:\sqlite-dll-win64-x64.zip -Force
 
 RUN powershell -Command \
 	$ErrorActionPreference = 'Stop'; \
-	Invoke-WebRequest -Method Get -Uri "https://www.sqlite.org/2016/sqlite-tools-win32-x86-3150000.zip" -OutFile c:\sqlite-tools-win32-x86-3150000.zip ; \
-	Expand-Archive -Path c:\sqlite-tools-win32-x86-3150000.zip -DestinationPath c:\sqlite ; \
-	Copy-Item -Path c:\sqlite\sqlite-tools-win32-x86-3150000\*.* c:\sqlite ; \
-	Remove-Item c:\sqlite\sqlite-tools-win32-x86-3150000 -Recurse -Force ; \
-	Remove-Item c:\sqlite-tools-win32-x86-3150000.zip -Force
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Method Get -Uri https://www.sqlite.org/2019/sqlite-tools-win32-x86-3270200.zip -OutFile c:\sqlite-tools-win32-x86.zip ; \
+	Expand-Archive -Path c:\sqlite-tools-win32-x86.zip -DestinationPath c:\sqlite ; \
+	Copy-Item -Path c:\sqlite\sqlite-tools-win32-x86-3270200\*.* c:\sqlite ; \
+	Remove-Item c:\sqlite\sqlite-tools-win32-x86-3270200 -Recurse -Force ; \
+	Remove-Item c:\sqlite-tools-win32-x86.zip -Force
 
 RUN setx /M PATH "%PATH%;c:\sqlite"
 

--- a/windows-container-samples/sqlite/README.md
+++ b/windows-container-samples/sqlite/README.md
@@ -31,21 +31,23 @@ docker run -it sqlite
 
 FROM microsoft/windowsservercore
 
-LABEL Description="SQLite" Vendor="SQLite" Version="3.12.0"
+LABEL Description="SQLite" Vendor="SQLite" Version="3.27.2"
 
 RUN powershell -Command \
 	$ErrorActionPreference = 'Stop'; \
-	Invoke-WebRequest -Method Get -Uri https://www.sqlite.org/2016/sqlite-dll-win64-x64-3120000.zip -OutFile c:\sqlite-dll-win64-x64-3120000.zip ; \
-	Expand-Archive -Path c:\sqlite-dll-win64-x64-3120000.zip -DestinationPath c:\sqlite ; \
-	Remove-Item c:\sqlite-dll-win64-x64-3120000.zip -Force
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Method Get -Uri https://www.sqlite.org/2019/sqlite-dll-win64-x64-3270200.zip -OutFile c:\sqlite-dll-win64-x64.zip ; \
+	Expand-Archive -Path c:\sqlite-dll-win64-x64.zip -DestinationPath c:\sqlite ; \
+	Remove-Item c:\sqlite-dll-win64-x64.zip -Force
 
 RUN powershell -Command \
 	$ErrorActionPreference = 'Stop'; \
-	Invoke-WebRequest -Method Get -Uri "https://www.sqlite.org/2016/sqlite-tools-win32-x86-3120000.zip" -OutFile c:\sqlite-tools-win32-x86-3120000.zip ; \
-	Expand-Archive -Path c:\sqlite-tools-win32-x86-3120000.zip -DestinationPath c:\sqlite ; \
-	Copy-Item -Path c:\sqlite\sqlite-tools-win32-x86-3120000\*.* c:\sqlite ; \
-	Remove-Item c:\sqlite\sqlite-tools-win32-x86-3120000 -Recurse -Force ; \
-	Remove-Item c:\sqlite-tools-win32-x86-3120000.zip -Force
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Method Get -Uri https://www.sqlite.org/2019/sqlite-tools-win32-x86-3270200.zip -OutFile c:\sqlite-tools-win32-x86.zip ; \
+	Expand-Archive -Path c:\sqlite-tools-win32-x86.zip -DestinationPath c:\sqlite ; \
+	Copy-Item -Path c:\sqlite\sqlite-tools-win32-x86-3270200\*.* c:\sqlite ; \
+	Remove-Item c:\sqlite\sqlite-tools-win32-x86-3270200 -Recurse -Force ; \
+	Remove-Item c:\sqlite-tools-win32-x86.zip -Force
 
 RUN setx /M PATH "%PATH%;c:\sqlite"
 


### PR DESCRIPTION
Hi,

today, I went over the windows-container-samples and noticed that some of them are not working anymore. For the ones that I fixed, this was because of old download links that were not available anymore, base images that were not correct anymore or because it could not use HTTPS URLs without this 'fancy' TLS1.2 command.

For the Dockerfiles that I touched, I also updated the product versions and the README files.

There are more samples that cannot be build, but I cannot fix them in appropriate time.