### PR TITLE
Correct mentions of "Azure Container Service" to use Azure Kubernetes Service instead in "About Windows container"

### DIFF
--- a/virtualization/hyper-v-on-windows/about/index.md
+++ b/virtualization/hyper-v-on-windows/about/index.md
@@ -35,7 +35,7 @@ Hyper-V is available on 64-bit versions of Windows 10 Pro, Enterprise, and Educa
 
 > Upgrade from Windows 10 Home edition to Windows 10 Pro by opening **Settings** > **Update and Security** > **Activation**. Here you can visit the store and purchase an upgrade.
 
-Most computers will run Hyper-V however each virtual machine is a completely seperate operating system.  You can generally run one or more virtual machines on a computer with 4GB of RAM, though you'll need more resources for additional virtual machines or to install and run resource intense software like games, video editing, or engineering design software.
+Most computers run Hyper-V, however each virtual machine runs a completely seperate operating system.  You can generally run one or more virtual machines on a computer with 4GB of RAM, though you'll need more resources for additional virtual machines or to install and run resource intense software like games, video editing, or engineering design software.
 
 For more information about Hyper-V's system requirements and how to verify that Hyper-V runs on your machine, see the [Hyper-V Requirements Reference](..\reference\hyper-v-requirements.md).
 

--- a/virtualization/hyper-v-on-windows/user-guide/nested-virtualization-azure-virtual-network.md
+++ b/virtualization/hyper-v-on-windows/user-guide/nested-virtualization-azure-virtual-network.md
@@ -115,7 +115,7 @@ I will gloss over any configuration values that are up to personal preference, s
 ## Configuring Remote Access
 
 1. Open Server Manager and select "Tools" and then select "Routing and Remote Access".
-2. On the right hand side of the Routing and Remote Access management panel you will see an icon with your servers name next to it, right click this and select "Configure and Enable Routing and Remote Access".
+2. On the left hand side of the Routing and Remote Access management panel you will see an icon with your servers name next to it, right click this and select "Configure and Enable Routing and Remote Access".
 3. At the wizard select "Next", check the radial button for "Custom Configuration", and then select "Next".
 4. Check “NAT” and “LAN routing” and then select “Next” and then “Finish”. If it asks you to start the service then do so.
 5. Now navigate to the “IPv4” node and expand it so that the “NAT” node is made available.

--- a/virtualization/windowscontainers/about/index.md
+++ b/virtualization/windowscontainers/about/index.md
@@ -105,9 +105,9 @@ Affinity/Anti-affinity: Specify that a set of containers should run nearby each 
 - Service discovery: Enable containers to locate each other automatically even as they move between host machines and change IP addresses.
 - Coordinated application upgrades: Manage container upgrades to avoid application down time and enable rollback if something goes wrong.
 
-Azure offers two container orchestrators: Azure Container Service (AKS) and Service Fabric.
+Azure offers two container orchestrators: Azure Kubernetes Service (AKS) and Service Fabric.
 
-[Azure Container Service (AKS)](/azure/aks/) makes it simple to create, configure, and manage a cluster of virtual machines that are preconfigured to run containerized applications. This enables you to use your existing skills, or draw upon a large and growing body of community expertise, to deploy and manage container-based applications on Microsoft Azure. By using AKS, you can take advantage of the enterprise-grade features of Azure, while still maintaining application portability through Kubernetes and the Docker image format.
+[Azure Kubernetes Service (AKS)](/azure/aks/) makes it simple to create, configure, and manage a cluster of virtual machines that are preconfigured to run containerized applications. This enables you to use your existing skills, or draw upon a large and growing body of community expertise, to deploy and manage container-based applications on Microsoft Azure. By using AKS, you can take advantage of the enterprise-grade features of Azure, while still maintaining application portability through Kubernetes and the Docker image format.
 
 [Azure Service Fabric](/azure/service-fabric/) is a distributed systems platform that makes it easy to package, deploy, and manage scalable and reliable microservices and containers. Service Fabric addresses the significant challenges in developing and managing cloud native applications. Developers and administrators can avoid complex infrastructure problems and focus on implementing mission-critical, demanding workloads that are scalable, reliable, and manageable. Service Fabric represents the next-generation platform for building and managing these enterprise-class, tier-1, cloud-scale applications running in containers.
 

--- a/virtualization/windowscontainers/about/index.md
+++ b/virtualization/windowscontainers/about/index.md
@@ -19,11 +19,11 @@ Containers are a way to wrap up an application into its own isolated box. For th
 
 Imagine a kitchen. We package up all the appliances and furniture, the pots and pans, the dish soap and hand towels. This is our container.
 
-<center style="margin: 25px">![](media/box1.png)</center>
+![](media/box1.png)
 
 We can now take this container and drop it into whatever host apartment we want, and it will be the same kitchen. All we must do is connect electricity and water to it, and then we’re clear to start cooking (because we have all the appliances we need!).
 
-<center style="margin: 25px">![](media/apartment.png)</center>
+![](media/apartment.png)
 
 In much the same way, containers are like this kitchen. There can be different kinds of rooms as well as many of the same kinds of rooms. What matters is that the containers come packaged up with everything they need.
 
@@ -49,7 +49,7 @@ The following key concepts will be helpful as you begin creating and working wit
 
 **Container Repository:** Each time a container image is created, the container image and its dependencies are stored in a local repository. These images can be reused many times on the container host. The container images can also be stored in a public or private registry, such as DockerHub, so that they can be used across many different container hosts.
 
-<center>![](media/containerfund.png)</center>
+![](media/containerfund.png)
 
 For someone familiar with virtual machines, containers may appear to be incredibly similar. A container runs an operating system, has a file system and can be accessed over a network just as if it was a physical or virtual computer system. However, the technology and concepts behind containers are vastly different from virtual machines.
 
@@ -69,7 +69,7 @@ Running a container on Windows with or without Hyper-V Isolation is a runtime de
 
 As you read about containers, you’ll inevitably hear about Docker. Docker is the vessel by which container images are packaged and delivered. This automated process produces images (effectively templates) which may then be run anywhere—on premises, in the cloud, or on a personal machine—as a container.
 
-<center>![](media/docker.png)</center>
+![](media/docker.png)
 
 Just like any other container, a Windows Server Container can be managed with [Docker](https://www.docker.com).
 

--- a/virtualization/windowscontainers/about/index.md
+++ b/virtualization/windowscontainers/about/index.md
@@ -47,7 +47,7 @@ The following key concepts will be helpful as you begin creating and working wit
 
 **Container OS Image:** Containers are deployed from images. The container OS image is the first layer in potentially many image layers that make up a container. This image provides the operating system environment. A Container OS Image is immutable. That is, it cannot be modified.
 
-**Container Repository:** Each time a container image is created, the container image and its dependencies are stored in a local repository. These images can be reused many times on the container host. The container images can also be stored in a public or private registry, such as DockerHub, so that they can be used across many different container hosts.
+**Container Repository:** Each time a container image is created, the container image and its dependencies are stored in a local repository. These images can be reused many times on the container host. The container images can also be stored in a public or private registry, such as Docker Hub, so that they can be used across many different container hosts.
 
 ![](media/containerfund.png)
 


### PR DESCRIPTION
Correct the doc of "About Windows container" mentions of "Azure Container Service" to be "Azure Kubernetes Service" instead.

Because Azure Container Service is deprecated, and all mentions of Kubernetes are using Azure Kubernetes Service as the official name of AKS. See also [AKS documentation landing page](https://docs.microsoft.com/en-us/azure/aks/).

Also correct the name of DockerHub, replaced with Docker's official "Docker Hub". Because the official name of Docker Hub **_is not_** DockerHub.

