### PR TITLE
Update the deprecated Azure Container Services to Azure Kubernetes Service instead

### DIFF
--- a/virtualization/windowscontainers/about/index.md
+++ b/virtualization/windowscontainers/about/index.md
@@ -47,7 +47,7 @@ The following key concepts will be helpful as you begin creating and working wit
 
 **Container OS Image:** Containers are deployed from images. The container OS image is the first layer in potentially many image layers that make up a container. This image provides the operating system environment. A Container OS Image is immutable. That is, it cannot be modified.
 
-**Container Repository:** Each time a container image is created, the container image and its dependencies are stored in a local repository. These images can be reused many times on the container host. The container images can also be stored in a public or private registry, such as DockerHub, so that they can be used across many different container hosts.
+**Container Repository:** Each time a container image is created, the container image and its dependencies are stored in a local repository. These images can be reused many times on the container host. The container images can also be stored in a public or private registry, such as Docker Hub, so that they can be used across many different container hosts.
 
 ![Container fundamentals](media/containerfund.png)
 
@@ -105,9 +105,9 @@ The standard definition of orchestration includes the following tasks:
 - Service discovery: Enable containers to locate each other automatically even as they move between host machines and change IP addresses.
 - Coordinated application upgrades: Manage container upgrades to avoid application down time and enable rollback if something goes wrong.
 
-Azure offers two container orchestrators: Azure Container Service (AKS) and Service Fabric.
+Azure offers two container orchestrators: Azure Kubernetes Service (AKS) and Service Fabric.
 
-[Azure Container Service (AKS)](/azure/aks/) makes it simple to create, configure, and manage a cluster of virtual machines that are preconfigured to run containerized applications. This enables you to use your existing skills, or draw upon a large and growing body of community expertise, to deploy and manage container-based applications on Microsoft Azure. By using AKS, you can take advantage of the enterprise-grade features of Azure, while still maintaining application portability through Kubernetes and the Docker image format.
+[Azure Kubernetes Service (AKS)](/azure/aks/) makes it simple to create, configure, and manage a cluster of virtual machines that are preconfigured to run containerized applications. This enables you to use your existing skills, or draw upon a large and growing body of community expertise, to deploy and manage container-based applications on Microsoft Azure. By using AKS, you can take advantage of the enterprise-grade features of Azure, while still maintaining application portability through Kubernetes and the Docker image format.
 
 [Azure Service Fabric](/azure/service-fabric/) is a distributed systems platform that makes it easy to package, deploy, and manage scalable and reliable microservices and containers. Service Fabric addresses the significant challenges in developing and managing cloud native applications. Developers and administrators can avoid complex infrastructure problems and focus on implementing mission-critical, demanding workloads that are scalable, reliable, and manageable. Service Fabric represents the next-generation platform for building and managing these enterprise-class, tier-1, cloud-scale applications running in containers.
 


### PR DESCRIPTION
Correct the doc of "About Windows container" mentions of "Azure Container Service" to be "Azure Kubernetes Service" instead.

Because Azure Container Service is deprecated, and all mentions of Kubernetes are using Azure Kubernetes Service as the official name of AKS. See also [AKS documentation landing page](https://docs.microsoft.com/en-us/azure/aks/).

Also correct the name of DockerHub, replaced with Docker's official "Docker Hub". Because the official name of Docker Hub **_is not_** DockerHub.
