### PR TITLE
Updates "Named Volumes" with note about case insensitivity

### DIFF
--- a/virtualization/windowscontainers/manage-containers/container-storage.md
+++ b/virtualization/windowscontainers/manage-containers/container-storage.md
@@ -133,3 +133,6 @@ Example steps:
 3. Write some files to c:\data in the container, then stop the container
 4. `docker run -v unwound:c:\data microsoft/windowsservercore` - Start a new container
 5. Run `dir c:\data` in the new container - the files are still there
+
+> [!NOTE]
+> Windows Server will convert target pathnames (the path inside of the container) to lower-case; i. e. `-v unwound:c:\MyData`, or `-v unwound:/app/MyData` in Linux containers, will result in a directory inside the container of `c:\mydata`, or `/app/mydata` in Linux containers, being mapped (and created, if not existent).


### PR DESCRIPTION
Windows Server will convert the target-path of a mounted volume to lower-case.

This is important if you use a Linux container or a Windows container with a case-sensitive filesystem.

(I can provide more info about use cases, or where you get "unexpected" behaviour without this information., if necessary.)