### PR TITLE
Corrected network adapter unbinding

### DIFF
--- a/windows-server-container-tools/CleanupContainerHostNetworking/WindowsContainerNetworking-LoggingAndCleanupAide.ps1
+++ b/windows-server-container-tools/CleanupContainerHostNetworking/WindowsContainerNetworking-LoggingAndCleanupAide.ps1
@@ -104,12 +104,12 @@ function ForceCleanupSystem
 
         foreach ($adapter in $adapters)
         {
-            if ($adapters.HardwareInterface -eq $true)
+            if ($adapter.HardwareInterface -eq $true)
             {
                 if ($adapter.Name) {
-                    Disable-NetAdapterBinding -Name $adapters.Name -ComponentID vms_pp
+                    Disable-NetAdapterBinding -Name $adapter.Name -ComponentID vms_pp
                 } elseif ($adapter.InterfaceDescription) {
-                    Disable-NetAdapterBinding -InterfaceDescription $adapters.InterfaceDescription -ComponentID vms_pp
+                    Disable-NetAdapterBinding -InterfaceDescription $adapter.InterfaceDescription -ComponentID vms_pp
                 }
             }
         }


### PR DESCRIPTION
I noticed that current code is using variable $adapter**s** inside of foreach loop which is incorrect.
It looks working fine on Windows Server 2016 because it does no list those non hardware interfaces without `-IncludeHidden` switch for `Get-NetAdapter` but because Windows Server 2019 does this need to be corrected.