### PR TITLE
fix param name

### DIFF
--- a/virtualization/windowscontainers/manage-containers/manage-serviceaccounts.md
+++ b/virtualization/windowscontainers/manage-containers/manage-serviceaccounts.md
@@ -97,7 +97,7 @@ Once you've decided on the name for your gMSA, run the following cmdlets in Powe
 # To install the AD module on older versions of Windows 10, see https://aka.ms/rsat
 
 # Create the security group
-New-ADGroup -Name "WebApp01 Authorized Hosts" -SamAccountName "WebApp01Hosts" -Scope DomainLocal
+New-ADGroup -Name "WebApp01 Authorized Hosts" -SamAccountName "WebApp01Hosts" -GroupScope DomainLocal
 
 # Create the gMSA
 New-ADServiceAccount -Name "WebApp01" -DnsHostName "WebApp01.contoso.com" -ServicePrincipalNames "host/WebApp01", "host/WebApp01.contoso.com" -PrincipalsAllowedToRetrieveManagedPassword "WebApp01Hosts"


### PR DESCRIPTION
The scope param for New-ADGroup is called -GroupScope, not -Scope. See https://docs.microsoft.com/en-us/powershell/module/addsadministration/new-adgroup?view=win10-ps#required-parameters