### PR TITLE
Resolve odd Windows 10 - 1903 host table information.

### DIFF
--- a/virtualization/windowscontainers/deploy-containers/version-compatibility.md
+++ b/virtualization/windowscontainers/deploy-containers/version-compatibility.md
@@ -67,11 +67,11 @@ As we've been improving the Windows container features, we've had to make some c
 
 |Container OS|Supports Hyper-V isolation|Supports process isolation|
 |---|:---:|:---:|
-|Windows Server, version 1903|No|No|
-|Windows Server 2019|No|No|
-|Windows Server, version 1803|No|No|
-|Windows Server, version 1709*|No|No|
-|Windows Server 2016|Yes|Yes|
+|Windows Server, version 1903|Yes|No|
+|Windows Server 2019|Yes|No|
+|Windows Server, version 1803|Yes|No|
+|Windows Server, version 1709*|Yes|No|
+|Windows Server 2016|Yes|No|
 
 ## Windows 10, version 1809 host OS compatibility
 


### PR DESCRIPTION
Addressed the comment #1186. Extrapolated what the logical support for Windows 10 - 1903 host would be as the table seems to have been copied from the above Windows Server 2016 table.