### PR TITLE
Fixed typos

### DIFF
--- a/virtualization/hyper-v-on-windows/index.md
+++ b/virtualization/hyper-v-on-windows/index.md
@@ -20,15 +20,15 @@ The following documents detail the Hyper-V feature in Windows 10, provide a guid
 The following articles provide an introduction to and information about Hyper-V on Windows.
 
 * [Introduction to Hyper-V](./about/index.md)
-* [Supported Guest Operating Systems](about\supported-guest-os.md)
+* [Supported Guest Operating Systems](about/supported-guest-os.md)
 
 ## Get started with Hyper-V
 The following documents provide a quick and guided introduction to Hyper-V on Windows 10.
 
-* [Install Hyper-V](quick-start\enable-hyper-v.md)
-* [Create a Virtual Machine](quick-start\create-virtual-machine.md)
-* [Create a Virtual Switch](quick-start\connect-to-network.md)
-* [Hyper-V and PowerShell](quick-start\try-hyper-v-powershell.md)
+* [Install Hyper-V](quick-start/enable-hyper-v.md)
+* [Create a Virtual Machine](quick-start/create-virtual-machine.md)
+* [Create a Virtual Switch](quick-start/connect-to-network.md)
+* [Hyper-V and PowerShell](quick-start/try-hyper-v-powershell.md)
 
 ## Connect with Community and Support
 Additional technical support and community resources.

--- a/virtualization/hyper-v-on-windows/quick-start/connect-to-network.md
+++ b/virtualization/hyper-v-on-windows/quick-start/connect-to-network.md
@@ -17,7 +17,7 @@ Your virtual machines will need a virtual network to share a network with your c
 
 ## Connect virtual machines to the internet
 
-Hyper-V has three types of virtual switches -- external, internal, and private. create an external switch to share your computer's network with the virtual machines running on it.
+Hyper-V has three types of virtual switches -- external, internal, and private. Create an external switch to share your computer's network with the virtual machines running on it.
 
 This exercise walks through creating an external virtual switch. Once completed, your Hyper-V host will have a virtual switch that can  connect virtual machines to the internet through your computer's network connection. 
 


### PR DESCRIPTION
index.md
The use of "\" instead of "/" on index.md was breaking links to other
documents while navigating through them on GitHub.
I also saw a page with a broken link to an image after navigating to one
of those links containing a "\".

connect-to-network.md contained a minor typo.