### PR TITLE
Fix Add-AdGroupMember SamAccountName members

### DIFF
--- a/virtualization/windowscontainers/manage-containers/manage-serviceaccounts.md
+++ b/virtualization/windowscontainers/manage-containers/manage-serviceaccounts.md
@@ -103,7 +103,7 @@ New-ADGroup -Name "WebApp01 Authorized Hosts" -SamAccountName "WebApp01Hosts" -G
 New-ADServiceAccount -Name "WebApp01" -DnsHostName "WebApp01.contoso.com" -ServicePrincipalNames "host/WebApp01", "host/WebApp01.contoso.com" -PrincipalsAllowedToRetrieveManagedPassword "WebApp01Hosts"
 
 # Add your container hosts to the security group
-Add-ADGroupMember -Identity "WebApp01Hosts" -Members "ContainerHost01", "ContainerHost02", "ContainerHost03"
+Add-ADGroupMember -Identity "WebApp01Hosts" -Members "ContainerHost01$", "ContainerHost02$", "ContainerHost03$"
 ```
 
 We recommend you create separate gMSA accounts for your dev, test, and production environments.


### PR DESCRIPTION
As per the documentation at https://docs.microsoft.com/en-us/powershell/module/addsadministration/add-adgroupmember

_"You can identify a new member by its distinguished name, GUID, security identifier, or SAM account name"_.

All computer objects in AD will have a SAM account name consisting of their netbios name, with a trailing '$'-sign. (e.g. ContainerHost01$)