### PR TITLE
"Get-HNSNetwork" cmdlet never works on WS2016

### DIFF
--- a/virtualization/windowscontainers/manage-docker/configure-docker-daemon.md
+++ b/virtualization/windowscontainers/manage-docker/configure-docker-daemon.md
@@ -203,6 +203,11 @@ After you uninstall Docker, you'll need to remove Docker's default networks so t
 Get-HNSNetwork | Remove-HNSNetwork
 ```
 
+To remove Docker's default networks on Windows Server 2016.
+```powershell
+Get-ContainerNetwork | Remove-ContainerNetwork
+```
+
 Run the following cmdlet to remove Docker's program data from your system:
 
 ```powershell


### PR DESCRIPTION
On section subheading "Clean up Docker data and system components",  "Get-HNSNetwork | Remove-HNSNetwork" cmdlet works fine on Windows 10, but it never works on Windows Server 2016. You should use  "Get-ContainerNetwork | Remove-ContainerNetwork" in place of "Get-HNSNetwork | Remove-HNSNetwork" on Windows Server 2016. My customer faced this issue on Windows Server 2016 and complained that this article was not correct.