### PR TITLE
Warn and let PCIe devices w/o ACS to go through

### DIFF
--- a/hyperv-tools/DiscreteDeviceAssignment/SurveyDDA.ps1
+++ b/hyperv-tools/DiscreteDeviceAssignment/SurveyDDA.ps1
@@ -46,8 +46,10 @@ foreach ($pcidev in $pcidevs) {
 
     $acsUp =  ($pcidev | Get-PnpDeviceProperty $devpkey_PciDevice_AcsCompatibleUpHierarchy).Data
     if ($acsUp -eq $devprop_PciDevice_AcsCompatibleUpHierarchy_NotSupported) {
-        write-host -ForegroundColor Red -BackgroundColor Black "Traffic from this device may be redirected to other devices in the system.  Not assignable."
-        continue
+        write-host -ForegroundColor Yellow -BackgroundColor Black "Warning: Traffic from this device may be redirected to other devices in the system."
+        write-host -ForegroundColor Yellow -BackgroundColor Black "It is strongly recommend to assign devices with proper ACS support for system security and reliability."
+        write-host -ForegroundColor Yellow -BackgroundColor Black "While it is possible to assign it to VM with -Force switch when running Dismount-VMHostAssignableDevice,"
+        write-host -ForegroundColor Yellow -BackgroundColor Black "PCIe security will not be enforced so all workloads should be trusted."
     }
 
     $devtype = ($pcidev | Get-PnpDeviceProperty $devpkey_PciDevice_DeviceType).Data


### PR DESCRIPTION
As suggested in the [team blog post](https://docs.microsoft.com/en-us/virtualization/community/team-blog/2015/20151120-discrete-device-assignment-machines-and-devices), the ACS requirement of PCIe devices can be overridden with `-Force` switch with risks of compromising the system security (VM isolation) and stability. Warn the user about possible consequences, but let the script to go through in such scenario.