### PR TITLE
[WindowsContainerNetworking-LoggingAndCleanupAide.ps1] Declutter

### DIFF
--- a/windows-server-container-tools/CleanupContainerHostNetworking/WindowsContainerNetworking-LoggingAndCleanupAide.ps1
+++ b/windows-server-container-tools/CleanupContainerHostNetworking/WindowsContainerNetworking-LoggingAndCleanupAide.ps1
@@ -239,13 +239,14 @@ function GetAllPolicies
 # -----------------------------------------------------------------------
 function CopyAllLogs
 {
-    Param(
+
+    Param (
         [string] $LogsPath
     )
 
     $LogsPath += "_$($script:namingSuffix)"
 
-    if (!(Test-Path $LogsPath))
+    If (!(Test-Path $LogsPath))
     {
         mkdir $LogsPath
     }
@@ -255,20 +256,20 @@ function CopyAllLogs
 
     $hns = Get-Service hns
 
-    try
+    Try
     {
-        if ($hns.Status -eq "Running")
+        If ($hns.Status -eq "Running")
         {
             net stop hns
         }
-        if (Test-Path "C:\ProgramData\Microsoft\Windows\HNS\HNS.data")
+        If (Test-Path "C:\ProgramData\Microsoft\Windows\HNS\HNS.data")
         {
             Copy-Item c:\ProgramData\Microsoft\Windows\HNS\HNS.data $LogsPath
         }
     }
-    finally
+    Finally
     {
-        if ($hns.Status -eq "Running")
+        If ($hns.Status -eq "Running")
         {
             net start hns
         }
@@ -302,13 +303,13 @@ function CopyAllLogs
     docker info > $LogsPath"\docker_info.txt"
 
     # Get list containing IDs of current container networks on host
-    $networks=docker network ls -q
+    $networks = docker network ls -q
 
     # Initialize file for recording network info
     "Number of container networks currently on this host: "+$networks.Length+"`\n" > $LogsPath"\docker_network_inspect.txt"
 
     # Inspect each network
-    foreach($network in $networks)
+    ForEach ($network in $networks)
     {
         $addMe = docker network inspect $network
         Add-Content $LogsPath"\docker_network_inspect.txt" $addMe
@@ -323,6 +324,7 @@ function CopyAllLogs
 
     Get-ChildItem HKLM:\SYSTEM\CurrentControlSet\Services\hns -Recurse > $LogsPath"\HNSRegistry.txt"
     Get-ChildItem HKLM:\SYSTEM\CurrentControlSet\Services\vmsmp -Recurse > $LogsPath"\vmsmpRegistry.txt"
+
 }
 
 # -----------------------------------------------------------------------

--- a/windows-server-container-tools/CleanupContainerHostNetworking/WindowsContainerNetworking-LoggingAndCleanupAide.ps1
+++ b/windows-server-container-tools/CleanupContainerHostNetworking/WindowsContainerNetworking-LoggingAndCleanupAide.ps1
@@ -276,10 +276,7 @@ function CopyAllLogs
 
     ipconfig /allcompartments /all > $LogsPath"\ipconfig.txt"
 
-
-
     Try
-
     {
 
         Resolve-Path "C:\Windows\System32\vfpctrl.exe" -ErrorAction Stop | Out-Null
@@ -315,11 +312,6 @@ function CopyAllLogs
     {
         $addMe = docker network inspect $network
         Add-Content $LogsPath"\docker_network_inspect.txt" $addMe
-    }
-
-    
-    if ((Get-WindowsFeature -Name Hyper-V).Installed -and (Get-Command Get-VMSwitch -ErrorAction SilentlyContinue)){
-        Get-VMSwitch | FL * > $LogsPath"\GetVMSwitch.txt"
     }
 
     Get-NetNat | FL * > $LogsPath"\GetNetNat.txt"


### PR DESCRIPTION
1. Remove redundant logging statements; the expected behaviour of the subsequent statements, [lines 321 to 323](https://github.com/MicrosoftDocs/Virtualization-Documentation/blob/9896a13d6a1ec4fc437e3904be07a9633310f844/windows-server-container-tools/CleanupContainerHostNetworking/WindowsContainerNetworking-LoggingAndCleanupAide.ps1#L321-L323), are already satisfied by [line 287](https://github.com/MicrosoftDocs/Virtualization-Documentation/blob/9896a13d6a1ec4fc437e3904be07a9633310f844/windows-server-container-tools/CleanupContainerHostNetworking/WindowsContainerNetworking-LoggingAndCleanupAide.ps1#L287) of 9896a13d6a1ec4fc437e3904be07a9633310f844.

https://github.com/MicrosoftDocs/Virtualization-Documentation/blob/9896a13d6a1ec4fc437e3904be07a9633310f844/windows-server-container-tools/CleanupContainerHostNetworking/WindowsContainerNetworking-LoggingAndCleanupAide.ps1#L321-L323

https://github.com/MicrosoftDocs/Virtualization-Documentation/blob/9896a13d6a1ec4fc437e3904be07a9633310f844/windows-server-container-tools/CleanupContainerHostNetworking/WindowsContainerNetworking-LoggingAndCleanupAide.ps1#L287
2. Minor syntax changes to uniform styles.