### PR TITLE
Update gmsa-run-container.md

### DIFF
--- a/virtualization/windowscontainers/manage-containers/gmsa-run-container.md
+++ b/virtualization/windowscontainers/manage-containers/gmsa-run-container.md
@@ -20,7 +20,7 @@ docker run --security-opt "credentialspec=file://contoso_webapp01.json" --hostna
 ```
 
 >[!IMPORTANT]
->On Windows Server 2016 versions 1709 and 1803, the hostname of the container must match the gMSA short name.
+>On Windows Server, versions 1709 and 1803, the hostname of the container must match the gMSA short name.
 
 In the previous example, the gMSA SAM Account Name is "webapp01," so the container hostname is also named "webapp01."
 


### PR DESCRIPTION
The product name was incorrectly added as Windows Server 2016 version 1709 and 1803. In fact, versions 1709 and 1803 are SAC releases and not related to Windows Server 2016 - which is an LTSC release and does not support gMSA.