### PR TITLE
 Fixed a mild "it's" bug

### DIFF
--- a/virtualization/hyper-v-on-windows/user-guide/nested-virtualization.md
+++ b/virtualization/hyper-v-on-windows/user-guide/nested-virtualization.md
@@ -42,7 +42,7 @@ Set-VMProcessor -VMName <VMName> -ExposeVirtualizationExtensions $false
 ```
 
 ## Dynamic Memory and Runtime Memory Resize
-When Hyper-V is running inside a virtual machine, the virtual machine must be turned off to adjust its memory. This means that even if dynamic memory is enabled, the amount of memory will not fluctuate. For virtual machines without dynamic memory enabled, any attempt to adjust the amount of memory while it's on will fail. 
+When Hyper-V is running inside a virtual machine, the virtual machine must be turned off to adjust its memory. This means that even if dynamic memory is enabled, the amount of memory will not fluctuate. For virtual machines without dynamic memory enabled, any attempt to adjust the amount of memory while its on will fail. 
 
 Note that simply enabling nested virtualization will have no effect on dynamic memory or runtime memory resize. The incompatibility only occurs while Hyper-V is running in the VM.
 


### PR DESCRIPTION
Tiny little fix: in context "it's" was used as a possessive, not a contraction of it is.