### PR TITLE
Showing Location for Already-Assigned Devices

### DIFF
--- a/hyperv-tools/DiscreteDeviceAssignment/SurveyDDA.ps1
+++ b/hyperv-tools/DiscreteDeviceAssignment/SurveyDDA.ps1
@@ -34,9 +34,12 @@ $pnpdevs = Get-PnpDevice -PresentOnly
 $pcidevs = $pnpdevs | Where-Object {$_.InstanceId -like "PCI*"}
 
 foreach ($pcidev in $pcidevs) {
+    $locationpath = ($pcidev | get-pnpdeviceproperty DEVPKEY_Device_LocationPaths).data[0]
     Write-Host ""
     Write-Host ""
     Write-Host -ForegroundColor White -BackgroundColor Black $pcidev.FriendlyName
+    Write-Host -ForegroundColor Yellow -BackgroundColor Black $locationpath
+    
 
     $rmrr =  ($pcidev | Get-PnpDeviceProperty $devpkey_PciDevice_RequiresReservedMemoryRegion).Data
     if ($rmrr -ne 0) {
@@ -66,8 +69,6 @@ foreach ($pcidev in $pcidevs) {
         }
     }
 
-    $locationpath = ($pcidev | get-pnpdeviceproperty DEVPKEY_Device_LocationPaths).data[0]
-
     #
     # If the device is disabled, we can't check the resources, report a warning and continue on.
     #
@@ -76,7 +77,6 @@ foreach ($pcidev in $pcidevs) {
     {
         Write-Host -ForegroundColor Yellow -BackgroundColor Black "Device is Disabled, unable to check resource requirements, it may be assignable."
         Write-Host -ForegroundColor Yellow -BackgroundColor Black "Enable the device and rerun this script to confirm."
-        $locationpath
         continue
     }
 
@@ -137,7 +137,6 @@ foreach ($pcidev in $pcidevs) {
     # change even if you add or remove devices from the machine or change the way that
     # the BIOS is configured.
     #
-    $locationpath
 }
 
 #


### PR DESCRIPTION
The script as is doesn't display the path for already-assigned devices. This is something you need to know if you already assigned a device over a year ago and have no memory of this place :)

Simple fix just moves the $locationpath variable up the chain and prints the path immediately after the friendly name regardless. Also removes the $locationpath prints later in the script since it has this new upfront print. Changes text to have black background and yellow foreground.