### PR TITLE
Add Windows 10, version 21H1 as a host operating system

### DIFF
--- a/virtualization/windowscontainers/deploy-containers/version-compatibility.md
+++ b/virtualization/windowscontainers/deploy-containers/version-compatibility.md
@@ -89,6 +89,17 @@ As we've been improving the Windows container features, we've had to make some c
 
 <!-- start tab view -->
 
+# [Windows 10, version 21H1](#tab/windows-10-21H1)
+
+|Container base image OS version|Supports Hyper-V isolation|Supports process isolation|
+|---|:---:|:---:|
+|Windows Server, version 20H2|&#10004;|&#10060;|
+|Windows Server, version 2004|&#10004;|&#10060;|
+|Windows Server, version 1909|&#10004;|&#10060;|
+|Windows Server, version 1903|&#10004;|&#10060;|
+|Windows Server 2019|&#10004;|&#10060;|
+|Windows Server 2016|&#10004;|&#10060;|
+
 # [Windows 10, version 20H2](#tab/windows-10-20H2)
 
 |Container base image OS version|Supports Hyper-V isolation|Supports process isolation|


### PR DESCRIPTION
This documents that there is no current container base image that will run in process isolation mode on a Windows 10 21H1 host.