### PR TITLE
Clarifying support on cluster shared volumes (CSV)

### DIFF
--- a/virtualization/windowscontainers/manage-containers/container-storage.md
+++ b/virtualization/windowscontainers/manage-containers/container-storage.md
@@ -25,7 +25,7 @@ As described in the [Containers Overview](../about/index.md), container images a
 In a default installation, layers are stored in `C:\ProgramData\docker` and split across the "image" and "windowsfilter" directories. You can change where the layers are stored using the `docker-root` configuration, as demonstrated in the [Docker Engine on Windows](../manage-docker/configure-docker-daemon.md) documentation.
 
 > [!NOTE]
-> Only NTFS is supported for layer storage. ReFS is not supported.
+> Only NTFS is supported for layer storage. ReFS and cluster shared volumes (CSV) are not supported.
 
 You should not modify any files in the layer directories - they're carefully managed using commands such as:
 

--- a/virtualization/windowscontainers/manage-containers/persistent-storage.md
+++ b/virtualization/windowscontainers/manage-containers/persistent-storage.md
@@ -20,6 +20,7 @@ Docker has a great overview of how to [use volumes](https://docs.docker.com/engi
 ## Bind Mounts
 
 [Bind mounts](https://docs.docker.com/engine/admin/volumes/bind-mounts/) allow a container to share a directory with the host. This is useful if you want a place to store files on the local machine that are available if you restart a container, or want to share it with multiple containers. If you want the container to run on multiple machines with access to the same files, then a named volume or SMB mount should be used instead.
+> [!NOTE] Bind mounting directly on cluster shared volumes (CSV) is not supported, virtual machines acting as a container host can run on a CSV volume.
 
 ### Permissions
 


### PR DESCRIPTION
While CSV works in some cases it is not a regularly validated scenario and does not have end-to-end support with orchestrators or failover clustering so we do not recommend/support it in production.