### PR TITLE
TLFS: Fix off-by-one bug in hypercall parameters definition

### DIFF
--- a/virtualization/hyper-v-on-windows/tlfs/hypercall-interface.md
+++ b/virtualization/hyper-v-on-windows/tlfs/hypercall-interface.md
@@ -76,7 +76,7 @@ Callers specify a hypercall by a 64-bit value called a hypercall input value. It
 | Rep Count               | 43-32   | Total number of reps (for rep call, must be zero otherwise) |
 | RsvdZ                   | 47-44   | Must be zero                                                |
 | Rep Start Index         | 59-48   | Starting index (for rep call, must be zero otherwise)       |
-| RsvdZ                   | 64-60   | Must be zero                                                |
+| RsvdZ                   | 63-60   | Must be zero                                                |
 
 For rep hypercalls, the rep count field indicates the total number of reps. The rep start index indicates the particular repetition relative to the start of the list (zero indicates that the first element in the list is to be processed). Therefore, the rep count value must always be greater than the rep start index.
 


### PR DESCRIPTION
TLFS has an off-by-one bug for the last reserved field, which it defines as
being bits 64:60.  The same section states "The input field 64-bit value
called a hypercall input value.", i.e. bit 64 doesn't exist.

Note: published TLFS versions up to 6.0b don't have this issue.

Reported-by: Sean Christopherson <seanjc@google.com>
Signed-off-by: Vitaly Kuznetsov <vkuznets@redhat.com>