### PR TITLE
Cmdlets use upper case for each word start-Process should be Start-Pr…

### DIFF
--- a/virtualization/windowscontainers/manage-docker/optimize-windows-dockerfile.md
+++ b/virtualization/windowscontainers/manage-docker/optimize-windows-dockerfile.md
@@ -137,7 +137,7 @@ RUN powershell -Command \
 
   Expand-Archive -Path c:\php.zip -DestinationPath c:\php ; \
   Expand-Archive -Path c:\apache.zip -DestinationPath c:\ ; \
-  start-Process c:\vcredist.exe -ArgumentList '/quiet' -Wait ; \
+  Start-Process c:\vcredist.exe -ArgumentList '/quiet' -Wait ; \
 
   # Remove unneeded files ; \
 
@@ -170,7 +170,7 @@ RUN powershell -Command \
 RUN powershell -Command \
     $ErrorActionPreference = 'Stop'; \
     wget "https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x86.exe" -OutFile c:\vcredist.exe ; \
-    start-Process c:\vcredist.exe -ArgumentList '/quiet' -Wait ; \
+    Start-Process c:\vcredist.exe -ArgumentList '/quiet' -Wait ; \
     Remove-Item c:\vcredist.exe -Force
 
 RUN powershell -Command \
@@ -291,7 +291,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
 RUN powershell -Command \
     $ErrorActionPreference = 'Stop'; \
-    start-Process c:\vcredist_x86.exe -ArgumentList '/quiet' -Wait ; \
+    Start-Process c:\vcredist_x86.exe -ArgumentList '/quiet' -Wait ; \
     Remove-Item c:\vcredist_x86.exe -Force ; \
     New-Item c:\config.ini
 ```


### PR DESCRIPTION
…ocess

The cmdlet Start-Process is used 6 times in the article. Three times the case is correct -- Start-Process. Three times it is used with the wrong case -- start-Process. I fixed the three incorrect instances.