### PR TITLE
fix: add extra tip about docker commit on windows

### DIFF
--- a/virtualization/windowscontainers/quick-start/run-your-first-container.md
+++ b/virtualization/windowscontainers/quick-start/run-your-first-container.md
@@ -60,6 +60,8 @@ For this simple example, a ‘Hello World’ container image will be created and
    ```
 
 4. Create a new ‘HelloWorld’ image that includes the changes in the first container you ran. To do so, run the [docker commit](https://docs.docker.com/engine/reference/commandline/commit/) command, replacing `<containerid>` with the ID of your container:
+   > [!TIP]
+   > You will need to stop your container first before committing, since committing a running container is not currently supported. Run `docker container stop <containerid>`.
 
    ```console
    docker commit <containerid> helloworld


### PR DESCRIPTION
You get the error when you try committing a running Windows docker image:
```
Error response from daemon: windows does not support commit of a running container
```
Commit works after the container is stopped.