### PR TITLE
Make sure alias `gwmi` is available

### DIFF
--- a/hyperv-tools/DiscreteDeviceAssignment/SurveyDDA.ps1
+++ b/hyperv-tools/DiscreteDeviceAssignment/SurveyDDA.ps1
@@ -35,6 +35,19 @@ $devprop_PciDevice_AcsCompatibleUpHierarchy_Supported                =   3
 #
 $devprop_PciDevice_BaseClass_DisplayCtlr                             =   3
 
+#
+# Check to see if gwmi is a valid alias on the system.
+# If it is not, make it one for the current PowerShell session.
+#
+if ($(Get-Alias -Name gwmi).Count -eq 0) { 
+    Set-Alias -Name gwmi -Value Get-WmiObject
+    if ($?) {
+        Write-Host -ForegroundColor Yellow -BackgroundColor Black "Created a temporary alias for the current session with the following command:"
+        Write-Host "    Set-Alias -Name gwmi -Value Get-WmiObject"
+	Write-Host ""
+    }
+}
+
 Write-Host "Executing SurveyDDA.ps1, revision 1"
 
 write-host "Generating a list of PCI Express endpoint devices"


### PR DESCRIPTION
`gwmi` is used in a loop, and when missing leads to high error message noise, making the output difficult to interpret (see example screenshot).

Check for the alias, and temporarily create it if required.


![PowerShell 7 shows terms it does not understand in the context of the command's syntax and line number, and uses red for the error message text, and blue for highlighting the term and line number.](https://user-images.githubusercontent.com/3385925/195980416-2317e949-2bb3-488b-b5b4-31eb00c664f5.png)
