### PR TITLE
fix: link to kubernetes

### DIFF
--- a/virtualization/windowscontainers/kubernetes/getting-started-kubernetes-windows.md
+++ b/virtualization/windowscontainers/kubernetes/getting-started-kubernetes-windows.md
@@ -18,7 +18,7 @@ This page serves as an overview for getting started with Kubernetes on Windows.
 
 ### Try out Kubernetes on Windows
 
-See [deploying Kubernetes on Windows](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/adding-windows-nodes/) for instructions on how to manually install Kubernetes on Windows in the environment of your choice.
+See [deploying Kubernetes on Windows](https://kubernetes.io/docs/concepts/windows/intro/) for instructions on how to manually install Kubernetes on Windows in the environment of your choice.
 
 
 ### Scheduling Windows containers


### PR DESCRIPTION
The link to Kubernetes redirects to a documentation that has no mention of Windows Containers.