### PR TITLE
Remove Windows 10 reference

### DIFF
--- a/virtualization/hyper-v-on-windows/index.md
+++ b/virtualization/hyper-v-on-windows/index.md
@@ -1,6 +1,6 @@
 ---
-title: Hyper-V on Windows 10 
-description: Hyper-V on Windows 10 
+title: Hyper-V on Windows 
+description: Hyper-V on Windows
 keywords: windows 10, hyper-v
 author: scooley
 ms.author: scooley
@@ -11,20 +11,22 @@ ms.assetid: 05269ce0-a54f-4ad8-af75-2ecf5142b866
 
 ---
 
-# Hyper-V on Windows 10 
+# Hyper-V on Windows
 
-Many versions of Windows 10 include the Hyper-V virtualization technology. Hyper-V enables running virtualized computer systems on top of a physical host. These virtualized systems can be used and managed just as if they were physical computer systems, however they exist in virtualized and isolated environment. Special software called a hypervisor manages access between the virtual systems and the physical hardware resources. Virtualization enables quick deployment of computer systems, a way to quickly restore systems to a previously known good state, and the ability to migrate systems between physical hosts.
+Many versions of Windows include the Hyper-V virtualization technology. Hyper-V enables running virtualized computer systems on top of a physical host. These virtualized systems can be used and managed just as if they were physical computer systems, however they exist in virtualized and isolated environment. Special software called a hypervisor manages access between the virtual systems and the physical hardware resources. Virtualization enables quick deployment of computer systems, a way to quickly restore systems to a previously known good state, and the ability to migrate systems between physical hosts.
 
-The following documents detail the Hyper-V feature in Windows 10, provide a guided quick start, and also contain links to further resources and community forums. 
+The following documents detail the Hyper-V feature in Windows, provide a guided quick start, and also contain links to further resources and community forums. 
 
 ## About Hyper-V on Windows
+
 The following articles provide an introduction to and information about Hyper-V on Windows.
 
 * [Introduction to Hyper-V](./about/index.md)
 * [Supported Guest Operating Systems](about/supported-guest-os.md)
 
 ## Get started with Hyper-V
-The following documents provide a quick and guided introduction to Hyper-V on Windows 10.
+
+The following documents provide a quick and guided introduction to Hyper-V on Windows.
 
 * [Install Hyper-V](quick-start/enable-hyper-v.md)
 * [Create a Virtual Machine](quick-start/create-virtual-machine.md)
@@ -32,6 +34,7 @@ The following documents provide a quick and guided introduction to Hyper-V on Wi
 * [Hyper-V and PowerShell](quick-start/try-hyper-v-powershell.md)
 
 ## Connect with Community and Support
+
 Additional technical support and community resources.
 
 * [Hyper-V forums](https://social.technet.microsoft.com/Forums/windowsserver/home?forum=winserverhyperv)


### PR DESCRIPTION
Can we just remove the references throughout these docs to Windows 10? Has anything significant changed for W11? I'd like to reference this Hyper-V doc, but don't want folks on W11 to be confused. 

If you'd like to discuss further via mail, just let me know.