### PR TITLE
Update base-image-lifecycle.md

### DIFF
--- a/virtualization/windowscontainers/deploy-containers/base-image-lifecycle.md
+++ b/virtualization/windowscontainers/deploy-containers/base-image-lifecycle.md
@@ -29,8 +29,8 @@ The following table lists each type of base image, its servicing channel, and ho
 |Server Core, Nano Server, Windows|Semi-Annual      |1909   |18363   |11/12/2019  |05/11/2021                |N/A                  |
 |Server Core, Nano Server, Windows|Semi-Annual      |1903   |18362   |05/21/2019  |12/08/2020                 |N/A                  |
 |Server Core                      |Long-Term, Semi-Annual        |2019, 1809   |17763   |11/13/2018  |01/09/2024                 |01/09/2029           |
-|Nano Server                      |Semi-Annual      |1809   |17763   |11/13/2018  |01/09/2024                 |N/A                  |
-|Windows             |Semi-Annual      |1809   |17763   |11/13/2018  |01/09/2024    | N/A                  |
+|Nano Server                      |Semi-Annual      |1809   |17763   |11/13/2018  |01/09/2024                 |01/09/2029                 |
+|Windows             |Semi-Annual      |1809   |17763   |11/13/2018  |01/09/2024    |01/09/2029         |
 |Server Core, Nano Server         |Semi-Annual      |1803   |17134   |04/30/2018  |11/12/2019                 |N/A                  |
 |Server Core, Nano Server         |Semi-Annual      |1709   |16299   |10/17/2017  |04/09/2019                 |N/A                  |
 |Server Core                      |Long-Term        |2016   |14393   |10/15/2016  |01/11/2022                 |01/11/2027           |


### PR DESCRIPTION
WS2019 container images will now reach the end of life in Jan 2029. Updating the documentation to reflect that.