### PR TITLE
Update enable-nested-virtualization.md

### DIFF
--- a/virtualization/hyper-v-on-windows/user-guide/enable-nested-virtualization.md
+++ b/virtualization/hyper-v-on-windows/user-guide/enable-nested-virtualization.md
@@ -29,6 +29,8 @@ To learn more about Nested Virtualization and supported scenarios, see [What is 
 
 >[!NOTE]
 > The guest can be any Windows supported guest operating system. Newer Windows operating systems may support enlightenments that improve performance.
+> To enable Nested Virtualization in an Azure VM, make sure to set Security Type as **"Standard"**.
+
 
 ## Configure Nested Virtualization
 


### PR DESCRIPTION
To enable Nested Virtualization in an Azure VM, Security Type should be set to "Standard".
 
By default, Security type would be "Trusted launch" which would cause issues while launching VMs on Hyper-V.