### PR TITLE
docs: add new section for windows services

### DIFF
--- a/virtualization/windowscontainers/manage-containers/container-security.md
+++ b/virtualization/windowscontainers/manage-containers/container-security.md
@@ -56,7 +56,7 @@ RUN net user username ‘<password>’ /ADD
 USER username
 ```
 
-## Windows Services
+## Windows services
 
 Microsoft Windows services, formerly known as NT services, enable you to create long-running executable applications that run in their own Windows sessions. These services can be automatically started when the operating system starts, can be paused and restarted, and do not show any user interface. You can also run services in the security context of a specific user account that is different from the logged-on user or the default computer account. 
 

--- a/virtualization/windowscontainers/manage-containers/container-security.md
+++ b/virtualization/windowscontainers/manage-containers/container-security.md
@@ -55,3 +55,11 @@ Alternatively, you can create a new user:
 RUN net user username ‘<password>’ /ADD
 USER username
 ```
+
+## Windows Services
+
+Microsoft Windows services, formerly known as NT services, enable you to create long-running executable applications that run in their own Windows sessions. These services can be automatically started when the operating system starts, can be paused and restarted, and do not show any user interface. You can also run services in the security context of a specific user account that is different from the logged-on user or the default computer account. 
+
+When containerizing and securing a workload that runs as a Windows service there are a few additional considerations to be aware of. First, the `ENTRYPOINT` of the container is not going to be the workload since the service runs as a background process, typically the `ENTRYPOINT` will be a tool like [service monitor](https://github.com/microsoft/IIS.ServiceMonitor)) or [log monitor](https://github.com/microsoft/windows-container-tools/tree/main/LogMonitor)). Second, the security account that the workload operates under will be configured by the service not by the USER directive in the dockerfile. You can check what account the service will run under by running `Get-WmiObject win32_service -filter "name='<servicename>'" | Format-List StartName`.
+
+For example, when hosting an IIS web application using the ASP.NET ([Microsoft Artifact Registry](https://mcr.microsoft.com/en-us/product/dotnet/framework/aspnet/about)) image the `ENTRYPOINT` of the container is `"C:\\ServiceMonitor.exe", "w3svc"`. This tool can be used to configure the IIS service and then monitors the service to ensure that it remains running and exits, thus stopping the container, if the service stops for any reason. By default, the IIS service and thus the web application run under a low privilege account within the container, but the service monitor tool requires administrative privileges to configure and monitor the service. 


### PR DESCRIPTION
Addresses a customer question around the use of ContainerUser as the account the entrypoint uses with service monitor.