### PR TITLE
windows containers: update version compatibility to include WS2025

### DIFF
--- a/virtualization/windowscontainers/deploy-containers/version-compatibility.md
+++ b/virtualization/windowscontainers/deploy-containers/version-compatibility.md
@@ -21,6 +21,16 @@ For any other scenario where there is a mismatch in host/guest Windows versionin
 ## Windows Server host OS compatibility
 
 <!-- start tab view -->
+# [Windows Server 2025](#tab/windows-server-2025)
+
+|Container base image OS version|Supports Hyper-V isolation|Supports process isolation|
+|---|:---:|:---:|
+|Windows Server 2025|&#10004;|&#10004;|
+|Windows Server 2022|&#10004;|&#10004;|
+|Windows Server 2019|&#10004;|&#10060;|
+|Windows Server 2016|&#10004;|&#10060;|
+
+<!-- start tab view -->
 # [Windows Server 2022](#tab/windows-server-2022)
 
 |Container base image OS version|Supports Hyper-V isolation|Supports process isolation|
@@ -56,9 +66,13 @@ For any other scenario where there is a mismatch in host/guest Windows versionin
 
 |Container base image OS version|Supports Hyper-V isolation|Supports process isolation|
 |---|:---:|:---:|
-|Windows Server 2022|&#10004;|&#10004;(preview)|
+|Windows Server 2025|&#10004; (*)|&#10004;(*)|
+|Windows Server 2022|&#10004;|&#10004;|
 |Windows Server 2019|&#10004;|&#10060;|
 |Windows Server 2016|&#10004;|&#10060;|
+
+>[!NOTE]
+>(*) Supported from Windows 11 24H2 (`Build 2600`) onwards.
 
 # [Windows 10](#tab/windows-10)
 


### PR DESCRIPTION
This commit updates the Windows Containers compatibility tables to include the newly released WS2025 server [1] and images [1]. 

__
[1] https://www.microsoft.com/en-us/evalcenter/download-windows-server-2025
[2] https://hub.docker.com/r/microsoft/windows-servercore