### PR TITLE
WHP docs tweak - add notes about where to find relevant headers and dlls

### DIFF
--- a/virtualization/api/hypervisor-platform/hypervisor-platform.md
+++ b/virtualization/api/hypervisor-platform/hypervisor-platform.md
@@ -14,7 +14,7 @@ The following diagram provides a high-level overview of the third-party architec
 
 ![Diagram of a high-level overview of the third-party architecture. Shows relationship between root partition and guest partition.](./../media/windows-hypervisor-platform-architecture.png)
 
-The following section contains the definitions of the Windows Hypervisor Platform APIs that are exposed through WinHvPlatform.h. WinHvApi.dll exports a set of C-style Windows API functions which return HRESULT error codes.
+The following section contains the definitions of the Windows Hypervisor Platform APIs that are exposed through [WinHvPlatform.h](headers/WinHvPlatform.h). WinHvPlatform.dll exports a set of C-style Windows API functions which return HRESULT error codes.
 
 ## Platform Capabilities
 

--- a/virtualization/api/hypervisor-platform/hypervisor-platform.md
+++ b/virtualization/api/hypervisor-platform/hypervisor-platform.md
@@ -14,7 +14,7 @@ The following diagram provides a high-level overview of the third-party architec
 
 ![Diagram of a high-level overview of the third-party architecture. Shows relationship between root partition and guest partition.](./../media/windows-hypervisor-platform-architecture.png)
 
-The following section contains the definitions of the Windows Hypervisor Platform APIs that are exposed through [WinHvPlatform.h](headers/WinHvPlatform.h). WinHvPlatform.dll exports a set of C-style Windows API functions which return HRESULT error codes.
+The following section contains the definitions of the Windows Hypervisor Platform APIs that are exposed through [WinHvPlatform.h](headers/WinHvPlatform.h). WinHvPlatform.dll (located in the System32 folder) exports a set of C-style Windows API functions which return HRESULT error codes. The headers are published with the [Windows SDK package](https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/).
 
 ## Platform Capabilities
 

--- a/virtualization/api/hypervisor-platform/hypervisor-platform.md
+++ b/virtualization/api/hypervisor-platform/hypervisor-platform.md
@@ -14,7 +14,7 @@ The following diagram provides a high-level overview of the third-party architec
 
 ![Diagram of a high-level overview of the third-party architecture. Shows relationship between root partition and guest partition.](./../media/windows-hypervisor-platform-architecture.png)
 
-The following section contains the definitions of the Windows Hypervisor Platform APIs that are exposed through [WinHvPlatform.h](headers/WinHvPlatform.h). WinHvPlatform.dll (located in the System32 folder) exports a set of C-style Windows API functions which return HRESULT error codes. The headers are published with the [Windows SDK package](https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/).
+The following section contains the definitions of the Windows Hypervisor Platform APIs that are exposed through [WinHvPlatform.h](headers/WinHvPlatform.h). WinHvPlatform.dll (located in the System32 folder) exports a set of C-style Windows API functions which return HRESULT error codes. The headers are published with the [Windows SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/) package.
 
 ## Platform Capabilities
 


### PR DESCRIPTION
WHP docs should point to where relevant headers can be ingested and what where the required DLL can be located to make it easier for folks onboarding or ramping up. 

Viewed with markdown viewer in VSCode to verify that there were no formatting issues. 

 