### PR TITLE
Fix the wrong GDT CS entry value

### DIFF
--- a/virtualization/api/hypervisor-platform/samples/WinHvSampleAmd64.cpp
+++ b/virtualization/api/hypervisor-platform/samples/WinHvSampleAmd64.cpp
@@ -204,7 +204,7 @@ void LongMode(void)
     const UINT64 gdtNullEntryIndex = 0;
     // GDT CS entry - page granularity, long, present, type code, execute\read\accessed
     const UINT16 csAttributes = 0xa09b;
-    const UINT64 gdtCsEntryValue = ((UINT64)csAttributes << 20);
+    const UINT64 gdtCsEntryValue = ((UINT64)csAttributes << 40);
     const UINT64 gdtCsEntryIndex = 1;
 
     uint64_t *gdtPage = static_cast<uint64_t *>(addressSpace.CommitRange(gdtSize, PAGE_READWRITE));


### PR DESCRIPTION
The attributes of GDT entry starts from the 40th bit, but it was wrongly set to start from the 20th bit.
<img width="2267" height="624" alt="image" src="https://github.com/user-attachments/assets/90d6fbb9-01ce-4516-a4fb-cfd298b655ff" />
